### PR TITLE
fix(proxy): allowlist /api/cron and /api/admin, tighten webhook match

### DIFF
--- a/proxy.ts
+++ b/proxy.ts
@@ -12,12 +12,20 @@ const JWT_SECRET_BYTES = new TextEncoder().encode(env.JWT_SECRET);
 
 export default async function proxy(req: NextRequest) {
   // Skip the session-cookie check for endpoints that authenticate
-  // themselves (sign-in exchanges a Farcaster Quick Auth token for our
-  // cookie; webhooks verify an HMAC signature; OG routes are public).
+  // themselves. Each one has its own credential path so we do not
+  // want the Farcaster session cookie layered on top:
+  //   - sign-in  → exchanges a Farcaster Quick Auth token for our cookie
+  //   - og       → public image routes
+  //   - webhooks → HMAC signature in the request body (e.g. Neynar)
+  //   - cron     → Authorization: Bearer ${CRON_SECRET} from Vercel Cron
+  //   - admin    → Authorization: Bearer ${ADMIN_API_TOKEN} from operators
+  const { pathname } = req.nextUrl;
   if (
-    req.nextUrl.pathname === "/api/auth/sign-in" ||
-    req.nextUrl.pathname.includes("/api/og") ||
-    req.nextUrl.pathname.includes("/api/webhook")
+    pathname === "/api/auth/sign-in" ||
+    pathname.startsWith("/api/og/") ||
+    pathname.startsWith("/api/webhooks/") ||
+    pathname.startsWith("/api/cron/") ||
+    pathname.startsWith("/api/admin/")
   ) {
     return NextResponse.next();
   }


### PR DESCRIPTION
## Summary

Production 401s on `GET /api/cron/reconcile` traced to the `/api/:path*` middleware rejecting Vercel Cron invocations before they reached the route. Cron and admin routes authenticate with `Authorization: Bearer` — not the Farcaster session cookie the middleware enforces — so they need explicit allowlist entries.

The previous webhook allowlist used `.includes('/api/webhook')`, which matched `/api/webhooks/neynar` only by substring coincidence (and would have matched `/api/webhookery/leak` too). Tightened to `startsWith`.

## What changed

- `/api/cron/*` allowlisted (route already checks `Authorization: Bearer \${CRON_SECRET}`)
- `/api/admin/*` allowlisted (route already checks `Authorization: Bearer \${ADMIN_API_TOKEN}`)
- `.includes` swapped for `startsWith` on all allowlist paths
- `/api/webhook` → `/api/webhooks/` (matches the actual directory name)

## Deploy notes

Make sure `CRON_SECRET` is set in Vercel prod env before merging. The reconcile route treats `CRON_SECRET` as opt-in auth — if it's unset the route is effectively public. With this middleware change, traffic now actually reaches the route, so unauthenticated invocations would execute the reconciler. Low blast radius (read-mostly, Privy-authoritative) but still worth locking down.

## Test plan

- [x] `pnpm typecheck` green
- [ ] Post-deploy: \`curl -I https://\$PROD/api/cron/reconcile -H "Authorization: Bearer \$CRON_SECRET"\` returns 200
- [ ] Post-deploy: same curl without the header returns 401 (from the route, not the middleware)
- [ ] Post-deploy: next Vercel Cron tick (≤ 5 min) shows a 200 in logs
- [ ] Post-deploy: Neynar webhook still 200s (belt-and-braces — the `startsWith` change keeps it allowlisted)

Made with [Cursor](https://cursor.com)