### PR TITLE
feat(privy): env-gate gas sponsorship (PRIVY_SPONSOR_GAS)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -56,6 +56,16 @@ SUPABASE_SERVICE_ROLE_KEY="sb_secret_xxx"
 PRIVY_APP_ID=""
 PRIVY_APP_SECRET=""
 
+# Whether Privy should sponsor gas for arena-wallet transactions.
+#   true  (default) — platform-sponsored via Privy's subscription plan.
+#                     Arena wallets never hold ETH. Requires an active
+#                     sponsorship subscription on the Privy dashboard.
+#   false           — arena wallets pay their own gas. Each wallet needs
+#                     a small ETH balance on Base (~0.0005 ETH covers
+#                     thousands of swaps). Set this in any environment
+#                     without an active Privy sponsorship plan.
+PRIVY_SPONSOR_GAS="true"
+
 # Base-mainnet EOA that receives fee-on-swap transfers from arena wallets.
 # Configure the same wallet in the Privy dashboard as the gas-sponsorship
 # top-up destination so fees self-refill the sponsorship balance.

--- a/README.md
+++ b/README.md
@@ -157,6 +157,16 @@ See `docs/mvp.md` § Gladiator Mint for the full flow.
 PRIVY_APP_ID=
 PRIVY_APP_SECRET=
 
+# Whether Privy sponsors gas for arena-wallet transactions.
+#   true  (default) — platform-sponsored; requires an active Privy
+#                     sponsorship subscription. Arena wallets never
+#                     hold ETH.
+#   false           — arena wallets pay their own gas. Each needs
+#                     ~0.0005 ETH on Base (dust — covers thousands of
+#                     swaps). Use this in any environment without an
+#                     active Privy sponsorship plan.
+PRIVY_SPONSOR_GAS=true
+
 # Base EOA that receives fee-on-swap transfers from arena wallets.
 # Configure the same wallet in the Privy dashboard as the
 # gas-sponsorship top-up destination so fees self-refill the balance.

--- a/lib/arena/withdraw.ts
+++ b/lib/arena/withdraw.ts
@@ -5,6 +5,7 @@ import { getAddress, isAddress, parseUnits, type Address } from "viem";
 import { USDC_BASE_ADDRESS, USDC_DECIMALS } from "@/lib/chain/addresses";
 import { readUsdcBalance } from "@/lib/chain/erc20";
 import { buildErc20TransferCalldata } from "@/lib/chain/erc20-calldata";
+import { env } from "@/lib/env";
 import { fetchUser } from "@/lib/neynar";
 import {
   PrivyApiError,
@@ -172,7 +173,7 @@ export async function withdrawUsdc(params: {
       walletId: arena.privyWalletId,
       to: USDC_BASE_ADDRESS,
       data: calldata,
-      sponsor: true,
+      sponsor: env.PRIVY_SPONSOR_GAS,
       referenceId,
     });
 

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -24,6 +24,20 @@ export const env = createEnv({
     // runtime when either is missing. See README § Privy setup.
     PRIVY_APP_ID: z.string().min(1).optional(),
     PRIVY_APP_SECRET: z.string().min(1).optional(),
+    // Whether Privy should sponsor gas for arena-wallet transactions.
+    // `true`  — platform-sponsored via Privy's subscription (the
+    //            long-term posture; arena wallets never hold ETH).
+    // `false` — arena wallets pay their own gas. Set this for any
+    //            environment without an active Privy sponsorship plan.
+    //            Each wallet needs a small ETH balance on Base
+    //            (~0.0005 ETH covers thousands of swaps).
+    // Accepts `true`/`false`/`1`/`0` (case-insensitive). Defaults to
+    // true so existing deployments are unaffected.
+    PRIVY_SPONSOR_GAS: z
+      .enum(["true", "false", "1", "0"])
+      .optional()
+      .default("true")
+      .transform((v) => v === "true" || v === "1"),
     // Base-mainnet EOA that receives fee-on-swap transfers. Required at
     // runtime by the execution pipeline (#8) but not by mint itself; kept
     // optional here so environments that haven't wired it yet still boot.

--- a/lib/execution/fee-transfer.ts
+++ b/lib/execution/fee-transfer.ts
@@ -79,7 +79,7 @@ export async function submitFeeTransfer(
     walletId: params.walletId,
     to: USDC_BASE_ADDRESS,
     data,
-    sponsor: true,
+    sponsor: env.PRIVY_SPONSOR_GAS,
     referenceId: params.referenceId,
   });
 }

--- a/lib/workflows/commodus-command.ts
+++ b/lib/workflows/commodus-command.ts
@@ -4,6 +4,7 @@ import { parseUnits, type Hex } from "viem";
 import { USDC_BASE_ADDRESS, USDC_DECIMALS } from "@/lib/chain/addresses";
 import { basePublicClient } from "@/lib/chain/client";
 import { buildAcceptedReply } from "@/lib/commodus/templates";
+import { env } from "@/lib/env";
 import { MissingSignerError } from "@/lib/neynar";
 import {
   PrivyTransactionFailedError,
@@ -444,7 +445,7 @@ async function submitSwap(params: {
     to: params.quoteTxTo,
     data: params.quoteTxData,
     value,
-    sponsor: true,
+    sponsor: env.PRIVY_SPONSOR_GAS,
     referenceId: params.executionId,
   });
 


### PR DESCRIPTION
## Summary

All three Privy call sites hardcoded \`sponsor: true\`. Privy rejects sponsored broadcasts when the project has no active sponsorship subscription, so \`submit_swap\` retries 3× then bubbles a \`FatalError\` — \`trade_executions\` is left at \`status='pending'\` with no \`tx_hash\` and the workflow never reaches \`publish_outcome_reply\`. Observed in prod after #22.

This PR makes sponsorship opt-in via \`PRIVY_SPONSOR_GAS\` without changing any default.

## Changes

- \`lib/env.ts\` — new \`PRIVY_SPONSOR_GAS\` boolean-coerced env. Accepts \`true\`/\`false\`/\`1\`/\`0\`, defaults to \`true\` (no behavior change for existing deployments).
- \`lib/workflows/commodus-command.ts\` — \`submit_swap\` now passes \`sponsor: env.PRIVY_SPONSOR_GAS\`.
- \`lib/execution/fee-transfer.ts\` — \`submitFeeTransfer\` same.
- \`lib/arena/withdraw.ts\` — \`withdrawUsdc\` same.
- \`.env.example\` + \`README.md\` — documents both postures and the ETH requirement for the unsponsored path.

## Deploy checklist (environments without a Privy sponsorship plan)

1. Set \`PRIVY_SPONSOR_GAS=false\` in Vercel prod env (and preview / development if you test there).
2. Redeploy (env reads happen at build).
3. Send ~0.0005 ETH on Base to every arena wallet that's already minted. Dust — covers thousands of swaps.
4. For wallets minted after this ships, the mint flow does NOT yet auto-fund ETH. Tracked separately: a \"mint-time ETH airdrop from operator treasury\" follow-up belongs in #9/arena-mint land, gated on the same flag.

Flipping back (once a Privy subscription is live): unset \`PRIVY_SPONSOR_GAS\` or set it to \`true\`, redeploy. No code change.

## Test plan

- [x] \`pnpm typecheck\` + \`pnpm test\` (49 tests) green
- [ ] Post-deploy: one \`@commo buy 1 usdc of aero\` cast completes \`pending → submitted → confirmed\` with \`tx_hash\` + \`fee_tx_hash\` populated and both intent + outcome replies visible
- [ ] Post-deploy: arena wallet's ETH balance decreases by the gas amount after a swap (confirming the unsponsored path is actually live, not silently falling back)
- [ ] Basescan shows the swap and fee transfers originating from the arena wallet (not a Privy-sponsored relay)

Made with [Cursor](https://cursor.com)