### PR TITLE
fix(execution): approve 0x AllowanceHolder before swap broadcast

### DIFF
--- a/lib/execution/allowance.ts
+++ b/lib/execution/allowance.ts
@@ -1,0 +1,111 @@
+import "server-only";
+
+import {
+  encodeFunctionData,
+  erc20Abi,
+  getAddress,
+  maxUint256,
+  type Hex,
+} from "viem";
+
+import { USDC_BASE_ADDRESS } from "@/lib/chain/addresses";
+import { basePublicClient } from "@/lib/chain/client";
+import { env } from "@/lib/env";
+import {
+  PrivyTransactionFailedError,
+  PrivyTransactionTimeoutError,
+  signAndSendTransaction,
+  waitForTransaction,
+} from "@/lib/privy/server";
+
+/**
+ * Ensures the arena wallet has sufficient USDC allowance for the 0x
+ * Allowance Holder spender returned by the quote.
+ *
+ * The 0x Allowance Holder flow requires the taker to have approved the
+ * AllowanceHolder contract (a single canonical Permit2-style spender)
+ * for the sell token prior to executing the swap. Without it, the swap
+ * calldata reverts on-chain with `ERC20: transfer amount exceeds
+ * allowance` during Privy's broadcast simulation.
+ *
+ * We approve for `MAX_UINT256` on first use so every subsequent swap
+ * from the same wallet/token pair is a single transaction. The on-chain
+ * `allowance(owner, spender)` read is free — calling it each swap keeps
+ * the module stateless and recovers correctly from lost DB rows.
+ *
+ * Idempotency:
+ *   - Replays after a successful approval see `allowance >= minRequired`
+ *     on the view call and short-circuit.
+ *   - The approval tx's `referenceId` is suffixed with `:approve` so it
+ *     doesn't collide with the swap's `execution_id`.
+ */
+export type EnsureAllowanceResult =
+  | { kind: "already-approved" }
+  | { kind: "approved"; txHash: Hex };
+
+export async function ensureUsdcAllowance(params: {
+  walletAddress: string;
+  privyWalletId: string;
+  spender: string;
+  minRequired: bigint;
+  referenceId: string;
+}): Promise<EnsureAllowanceResult> {
+  const owner = getAddress(params.walletAddress);
+  const spender = getAddress(params.spender);
+
+  const current = await basePublicClient.readContract({
+    address: USDC_BASE_ADDRESS,
+    abi: erc20Abi,
+    functionName: "allowance",
+    args: [owner, spender],
+  });
+
+  if (current >= params.minRequired) {
+    return { kind: "already-approved" };
+  }
+
+  const data = encodeFunctionData({
+    abi: erc20Abi,
+    functionName: "approve",
+    args: [spender, maxUint256],
+  });
+
+  const submitted = await signAndSendTransaction({
+    walletId: params.privyWalletId,
+    to: USDC_BASE_ADDRESS,
+    data,
+    sponsor: env.PRIVY_SPONSOR_GAS,
+    referenceId: `${params.referenceId}:approve`,
+  });
+
+  let hash = submitted.hash as Hex | "";
+  if (!hash) {
+    try {
+      const { hash: waited } = await waitForTransaction(
+        submitted.transactionId,
+        { timeoutMs: 30_000 },
+      );
+      hash = waited as Hex;
+    } catch (err) {
+      if (
+        err instanceof PrivyTransactionTimeoutError ||
+        err instanceof PrivyTransactionFailedError
+      ) {
+        throw new Error(
+          `ensure_allowance: approval did not confirm (${err.name})`,
+        );
+      }
+      throw err;
+    }
+  }
+
+  // Wait for the receipt so the downstream swap step sees the new
+  // allowance on the public RPC. Without this the swap can still race
+  // the mempool-to-block lag and re-hit the same allowance revert.
+  await basePublicClient.waitForTransactionReceipt({
+    hash: hash as Hex,
+    timeout: 30_000,
+  });
+
+  return { kind: "approved", txHash: hash as Hex };
+}

--- a/lib/workflows/commodus-command.ts
+++ b/lib/workflows/commodus-command.ts
@@ -18,6 +18,7 @@ import {
   ZeroxNotConfiguredError,
 } from "@/lib/zerox/quote";
 
+import { ensureUsdcAllowance } from "@/lib/execution/allowance";
 import {
   submitFeeTransfer,
   OperatorTreasuryNotConfiguredError,
@@ -58,9 +59,9 @@ export interface CommandContext {
  *
  * Flow (issue #8 § Workflow):
  *   load_command → parse → policy_validate → compute_fee → quote_swap →
- *   publish_intent_reply → submit_swap → transfer_fee → verify_tx →
- *   decode_swap_log → score_time_enforcement → update_lots_and_positions →
- *   score_trade → publish_outcome_reply
+ *   publish_intent_reply → ensure_allowance → submit_swap → transfer_fee →
+ *   verify_tx → decode_swap_log → score_time_enforcement →
+ *   update_lots_and_positions → score_trade → publish_outcome_reply
  *
  * Every step is `'use step'` and either pure or idempotent check-then-
  * act. Replays land on the same `execution_id` reservation and pick up
@@ -153,6 +154,15 @@ export async function handleCommodusCommand(ctx: CommandContext) {
   await markStatus(ctx.castHash, "quoted");
 
   await publishIntentReply(ctx.castHash, buildIntentReply(intent));
+
+  // Guarantees `USDC.allowance(arenaWallet, AllowanceHolder) >= sellAmount`.
+  // A no-op read for wallets that already MAX-approved on a prior swap.
+  await ensureAllowanceStep({
+    ctx: policy.context,
+    spender: reservation.txTo,
+    sellAmountBaseUnits: reservation.sellAmountBaseUnits,
+    executionId,
+  });
 
   const submitted: { txHash: string; privyTransactionId: string | null } =
     reservation.txHash
@@ -348,6 +358,8 @@ type QuoteAndReserveReturn = ReservedExecution & {
   txTo: string;
   txData: string;
   txValue: string;
+  /** USDC sell amount in base units, serialized as a string (BigInt → string). */
+  sellAmountBaseUnits: string;
 };
 
 async function quoteAndReserve(params: {
@@ -403,6 +415,7 @@ async function quoteAndReserve(params: {
     txTo: quote.transaction.to,
     txData: quote.transaction.data,
     txValue: quote.transaction.value,
+    sellAmountBaseUnits: sellAmount.toString(),
   };
 }
 
@@ -419,6 +432,33 @@ async function publishIntentReply(castHash: string, text: string): Promise<void>
     if (err instanceof MissingSignerError) throw new FatalError(err.message);
     throw err;
   }
+}
+
+// ---------------------------------------------------------------------------
+// Step: ensure_allowance
+// ---------------------------------------------------------------------------
+
+/**
+ * Guarantees the arena wallet has approved the 0x Allowance Holder
+ * contract to pull its USDC. The first swap for a wallet broadcasts a
+ * one-time MAX_UINT approve; subsequent swaps short-circuit on the
+ * allowance view call. See `lib/execution/allowance.ts` for details.
+ */
+async function ensureAllowanceStep(params: {
+  ctx: PolicyContext;
+  spender: string;
+  sellAmountBaseUnits: string;
+  executionId: string;
+}): Promise<void> {
+  "use step";
+
+  await ensureUsdcAllowance({
+    walletAddress: params.ctx.walletAddress,
+    privyWalletId: params.ctx.privyWalletId,
+    spender: params.spender,
+    minRequired: BigInt(params.sellAmountBaseUnits),
+    referenceId: params.executionId,
+  });
 }
 
 // ---------------------------------------------------------------------------

--- a/lib/zerox/quote.ts
+++ b/lib/zerox/quote.ts
@@ -9,10 +9,8 @@ import { env } from "@/lib/env";
  *
  * We use the Allowance Holder flow so the arena wallet approves a
  * single canonical contract (0x's AllowanceHolder) for MAX_UINT once
- * per token, then every subsequent swap is a single `eth_sendTransaction`
- * to that same contract. No per-swap approval dance — relevant given
- * every tx is gas-sponsored and we want to minimize the sponsored
- * surface area.
+ * per token; every subsequent swap is a single `eth_sendTransaction`
+ * to that same contract.
  *
  * Docs: https://0x.org/docs/api#tag/Swap/operation/swap::allowanceHolder::getQuote
  *
@@ -22,8 +20,11 @@ import { env } from "@/lib/env";
  *     workflow step can branch on them cleanly.
  *
  * What it intentionally does NOT cover:
- *   - Approval bookkeeping (callers should track per-wallet allowance
- *     state separately; for MVP we set max approval at mint time).
+ *   - Approval issuance — handled by `lib/execution/allowance.ts`
+ *     (`ensureUsdcAllowance`), invoked from the workflow's
+ *     `ensure_allowance` step before each swap. Stateless: reads the
+ *     current on-chain allowance and submits a MAX_UINT approval only
+ *     when the wallet is under-approved.
  *   - Price vs quote distinction (we only need quote+calldata).
  *   - Sell-side sizing (MVP is buy-only; sells add post-MVP).
  */


### PR DESCRIPTION
## The bug

On fresh arena wallets, the very first `@commodus buy` cast fails at `submit_swap` with:

```
PrivyApiError: Privy API error 400: "Execution reverted with reason: ERC20: transfer amount exceeds allowance"
```

Root cause: the 0x Allowance Holder flow requires the taker to have approved 0x's `AllowanceHolder` contract for the sell token *before* executing the swap calldata. The pipeline in #8 assumed that approval was done at wallet-mint time (per the comment in `lib/zerox/quote.ts`), but it never actually was. Every new arena wallet hits the revert on its first trade.

Privy catches the revert during its broadcast simulation, so no gas is spent — the tx never hits the chain — but the workflow's `submit_swap` step fatal-errors after its retry budget, leaving the cast stuck in `quoted` status with a `pending` `trade_executions` row.

## The fix

Add an `ensure_allowance` step between `publish_intent_reply` and `submit_swap`:

1. Reads `USDC.allowance(arenaWallet, spender)` from Base — free view call.
2. If the allowance covers the sellAmount → no-op. This is the fast path for every swap after the first and for all workflow replays.
3. Otherwise submits `USDC.approve(spender, MAX_UINT256)` via Privy and waits for the receipt so the downstream swap call sees the new allowance on the public RPC.

The spender comes from `quote.transaction.to` (AllowanceHolder v2 on Base) — no hardcoded addresses. Gas for the approval respects the same `PRIVY_SPONSOR_GAS` env flag as every other arena-wallet tx.

Approving `MAX_UINT256` once per wallet (rather than exact-amount per swap) matches the Allowance Holder design recommendation and keeps the hot path a single transaction.

## Files

- **`lib/execution/allowance.ts`** (new) — stateless `ensureUsdcAllowance` helper.
- **`lib/workflows/commodus-command.ts`** — new `ensure_allowance` workflow step; `quoteAndReserve` now returns `sellAmountBaseUnits` so downstream steps can size the allowance check.
- **`lib/zerox/quote.ts`** — module-level comment updated; the *"max approval at mint time"* line was stale and misleading.

## Replay safety

- The allowance view call short-circuits any replay after a successful approval — no redundant approvals.
- The approval tx's `referenceId` is suffixed with `:approve` so it doesn't collide with the swap's `execution_id` in Privy's reference_id logs.
- No new DB columns or tables — fully stateless.

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm test` — 49/49 vitest tests pass
- [ ] Live: cast `@commo buy 1 usdc of aero`, observe the approval tx on BaseScan followed by a successful swap
- [ ] Live: cast a second trade with the same wallet, observe `ensure_allowance` short-circuits (no approval tx, swap only)

## Unblocks

Currently blocking end-to-end validation of #8 in production. After merge + deploy, the next fresh-wallet cast should progress past `submit_swap` through the full `confirm_swap → submit_fee_transfer → publish_outcome_reply` sequence.

Made with [Cursor](https://cursor.com)