### PR TITLE
feat(commodus): full command grammar via regex + AI SDK fallback (#9)

### DIFF
--- a/lib/commodus/command-parser.test.ts
+++ b/lib/commodus/command-parser.test.ts
@@ -1,0 +1,220 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { generateText } from "ai";
+
+import { parseCommandIntent } from "@/lib/execution/parse";
+
+/**
+ * End-to-end coverage of the Stage 2 LLM fallback wired through
+ * `parseCommandIntent`. The regex pre-filter is exercised by
+ * `lib/commodus/parser.test.ts`; this file only exercises inputs the
+ * regex does not match, so every test here flows through the injected
+ * fake `generateText`.
+ *
+ * We swap the LLM dependency via the `opts.llm.generate` injection
+ * seam exposed by `parseCommandIntent` — no live gateway call is
+ * made. The fake returns a minimal `{ output }` object that matches
+ * the subset of the AI SDK v6 `generateText` result contract the
+ * parser consumes.
+ */
+
+type GenerateText = typeof generateText;
+type FakeResult = Awaited<ReturnType<GenerateText>>;
+
+/**
+ * Tiny helper that builds a `generateText` stand-in returning a
+ * scripted sequence of outputs (object) or errors. Keeps the test
+ * surface focused on behavior, not on re-casting the SDK's full
+ * result shape.
+ */
+function makeFakeLlm(
+  sequence: ReadonlyArray<unknown | Error>,
+): { generate: GenerateText; callCount: () => number } {
+  let calls = 0;
+  const generate = (async () => {
+    const value = sequence[calls] ?? sequence[sequence.length - 1];
+    calls += 1;
+    if (value instanceof Error) throw value;
+    return { output: value } as FakeResult;
+  }) as unknown as GenerateText;
+  return { generate, callCount: () => calls };
+}
+
+describe("parseCommandIntent — LLM fallback (happy paths)", () => {
+  it("parses a casual buy phrasing the regex can't handle", async () => {
+    const { generate, callCount } = makeFakeLlm([
+      {
+        action: "buy",
+        symbol: "AERO",
+        amount_type: "usdc_in",
+        amount_value: 2,
+      },
+    ]);
+
+    const outcome = await parseCommandIntent(
+      "@commodus grab 2 usdc worth of aero",
+      { llm: { generate, maxRetries: 0 } },
+    );
+
+    expect(outcome).toEqual({
+      ok: true,
+      intent: {
+        action: "buy",
+        symbol: "AERO",
+        amount_type: "usdc_in",
+        amount_value: 2,
+      },
+    });
+    expect(callCount()).toBe(1);
+  });
+
+  it("parses a casual sell phrasing with an implied percent", async () => {
+    const { generate } = makeFakeLlm([
+      {
+        action: "sell",
+        symbol: "AERO",
+        amount_type: "percent_out",
+        amount_value: 50,
+      },
+    ]);
+
+    const outcome = await parseCommandIntent("@commodus sell half my aero", {
+      llm: { generate, maxRetries: 0 },
+    });
+
+    expect(outcome).toEqual({
+      ok: true,
+      intent: {
+        action: "sell",
+        symbol: "AERO",
+        amount_type: "percent_out",
+        amount_value: 50,
+      },
+    });
+  });
+
+  it("parses a casual status phrasing", async () => {
+    const { generate } = makeFakeLlm([{ action: "status" }]);
+
+    const outcome = await parseCommandIntent("@commodus what's my rank", {
+      llm: { generate, maxRetries: 0 },
+    });
+
+    expect(outcome).toEqual({ ok: true, intent: { action: "status" } });
+  });
+});
+
+describe("parseCommandIntent — retry-once, then hard-fail", () => {
+  it("retries once on a schema-invalid LLM response, then rejects as grammar", async () => {
+    // Two invalid payloads — retry budget of 1 is exhausted, and the
+    // parser surfaces `grammar_error` so the workflow publishes the
+    // templated Commodus Voice rejection.
+    const { generate, callCount } = makeFakeLlm([
+      { action: "buy" /* missing required fields */ },
+      { action: "buy" /* still missing */ },
+    ]);
+
+    const outcome = await parseCommandIntent("@commodus do something weird", {
+      llm: { generate, maxRetries: 1 },
+    });
+
+    expect(outcome).toMatchObject({ ok: false, reason: "grammar_error" });
+    expect(callCount()).toBe(2);
+  });
+
+  it("retries once on a provider error, then rejects as grammar", async () => {
+    const { generate, callCount } = makeFakeLlm([
+      new Error("gateway 503"),
+      new Error("gateway 503"),
+    ]);
+
+    const outcome = await parseCommandIntent(
+      "@commodus gibberish that won't parse",
+      { llm: { generate, maxRetries: 1 } },
+    );
+
+    expect(outcome).toMatchObject({ ok: false, reason: "grammar_error" });
+    expect(callCount()).toBe(2);
+  });
+
+  it("treats an explicit `invalid` LLM response as a retry-then-grammar failure", async () => {
+    const { generate, callCount } = makeFakeLlm([
+      { action: "invalid" },
+      { action: "invalid" },
+    ]);
+
+    const outcome = await parseCommandIntent("@commodus gm", {
+      llm: { generate, maxRetries: 1 },
+    });
+
+    expect(outcome).toMatchObject({ ok: false, reason: "grammar_error" });
+    expect(callCount()).toBe(2);
+  });
+
+  it("accepts the second attempt when the first response was malformed", async () => {
+    const { generate, callCount } = makeFakeLlm([
+      { action: "invalid" },
+      {
+        action: "buy",
+        symbol: "AERO",
+        amount_type: "usdc_in",
+        amount_value: 3,
+      },
+    ]);
+
+    const outcome = await parseCommandIntent(
+      "@commodus put 3 usdc into aero",
+      { llm: { generate, maxRetries: 1 } },
+    );
+
+    expect(outcome).toMatchObject({
+      ok: true,
+      intent: { action: "buy", symbol: "AERO", amount_value: 3 },
+    });
+    expect(callCount()).toBe(2);
+  });
+});
+
+describe("parseCommandIntent — regex precedence", () => {
+  it("never invokes the LLM on the canonical AERO-buy regex happy path", async () => {
+    const generate = vi.fn() as unknown as GenerateText;
+
+    const outcome = await parseCommandIntent("@commodus buy 5 usdc of aero", {
+      llm: { generate, maxRetries: 1 },
+    });
+
+    expect(outcome).toEqual({
+      ok: true,
+      intent: {
+        action: "buy",
+        symbol: "AERO",
+        amount_type: "usdc_in",
+        amount_value: 5,
+      },
+    });
+    expect(generate).not.toHaveBeenCalled();
+  });
+
+  it("short-circuits on asset_error without an LLM call", async () => {
+    const generate = vi.fn() as unknown as GenerateText;
+
+    const outcome = await parseCommandIntent("@commodus buy 5 usdc of weth", {
+      llm: { generate, maxRetries: 1 },
+    });
+
+    expect(outcome).toMatchObject({ ok: false, reason: "asset_error" });
+    expect(generate).not.toHaveBeenCalled();
+  });
+
+  it("short-circuits on oversize_error without an LLM call", async () => {
+    const generate = vi.fn() as unknown as GenerateText;
+
+    const outcome = await parseCommandIntent(
+      "@commodus buy 100 usdc of aero",
+      { llm: { generate, maxRetries: 1 } },
+    );
+
+    expect(outcome).toMatchObject({ ok: false, reason: "oversize_error" });
+    expect(generate).not.toHaveBeenCalled();
+  });
+});

--- a/lib/commodus/parser.test.ts
+++ b/lib/commodus/parser.test.ts
@@ -139,7 +139,10 @@ describe("parseCommand — grammar rejections", () => {
     });
   });
 
-  it("rejects sell and status verbs (deferred to #9/#13)", () => {
+  it("rejects sell and status verbs at the regex layer (handled by the LLM fallback in #9)", () => {
+    // Stage 1 is a strict AERO-buy regex; sell and status verbs miss
+    // the pattern here and are routed to `parseCommandIntent`'s LLM
+    // fallback. See `lib/execution/parse.ts` + `llm-parse.ts`.
     expect(parseCommand("@commo sell 100% of aero")).toEqual({
       kind: "grammar_error",
     });

--- a/lib/commodus/templates.ts
+++ b/lib/commodus/templates.ts
@@ -19,7 +19,7 @@ export type RejectionReason =
  */
 export const REJECTION_REPLIES: Record<RejectionReason, string> = {
   grammar:
-    "Speak as Rome taught you, gladiator. Valid decrees: `buy N usdc of aero`.",
+    "Speak as Rome taught you, gladiator. Valid decrees: `buy N usdc of SYMBOL`, `sell N% of SYMBOL`, `status`.",
   no_arena_wallet:
     "Enter the arena first, gladiator. Open the Mini App to designate thine arena address.",
   non_whitelisted_token: "Order denied. Asset not approved for this arena.",

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -52,10 +52,19 @@ export const env = createEnv({
     // the quote_swap pipeline step; optional at build so environments
     // without it still boot.
     ZEROX_API_KEY: z.string().min(1).optional(),
-    // OpenAI API key for the Vercel AI SDK `generateObject` fallback in
-    // the parser. The regex pre-filter handles the happy path without it;
-    // unset environments fall back to regex-only behavior.
+    // OpenAI API key for direct-provider fallback. Kept for forward-compat
+    // with providers that haven't moved behind the gateway yet; the
+    // command parser (#9) routes via the AI Gateway. Optional at build,
+    // so unset environments still boot.
     OPENAI_API_KEY: z.string().min(1).optional(),
+    // Vercel AI Gateway API key used by the command parser's LLM fallback
+    // (issue #9). Vercel deployments auto-authenticate via OIDC and don't
+    // need it set; self-hosted envs do. Optional at build (the regex
+    // pre-filter handles canonical `buy N usdc of SYMBOL` phrasing
+    // without any LLM call, so `pnpm build` succeeds without it). The
+    // LLM fallback path throws at runtime if both this and OIDC are
+    // unavailable.
+    AI_GATEWAY_API_KEY: z.string().min(1).optional(),
     // Shared secret for `/api/admin/*` endpoints (reconciler trigger,
     // future ops tooling). Bearer token in Authorization header. Required
     // at runtime by the admin reconciler route; optional at build.

--- a/lib/execution/intents.test.ts
+++ b/lib/execution/intents.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
 
-import { TradeIntentSchema, isUsdcInIntent } from "./intents";
+import {
+  CommandIntentSchema,
+  TradeIntentSchema,
+  isTradeIntent,
+  isUsdcInIntent,
+} from "./intents";
 
 describe("TradeIntentSchema", () => {
   it("accepts a canonical buy intent", () => {
@@ -18,13 +23,16 @@ describe("TradeIntentSchema", () => {
     });
   });
 
-  it("defaults amount_type to usdc_in", () => {
-    const parsed = TradeIntentSchema.parse({
-      action: "buy",
-      symbol: "AERO",
-      amount_value: 1,
-    });
-    expect(parsed.amount_type).toBe("usdc_in");
+  it("rejects buys without the usdc_in discriminant", () => {
+    // Discriminated union: `action: "buy"` pins `amount_type: "usdc_in"`.
+    expect(() =>
+      TradeIntentSchema.parse({
+        action: "buy",
+        symbol: "AERO",
+        amount_type: "percent_out",
+        amount_value: 5,
+      }),
+    ).toThrow();
   });
 
   it("rejects lowercased or dashed symbols", () => {
@@ -32,16 +40,18 @@ describe("TradeIntentSchema", () => {
       TradeIntentSchema.parse({
         action: "buy",
         symbol: "aero",
+        amount_type: "usdc_in",
         amount_value: 1,
       }),
     ).toThrow();
   });
 
-  it("rejects zero or negative amounts", () => {
+  it("rejects zero or negative buy amounts", () => {
     expect(() =>
       TradeIntentSchema.parse({
         action: "buy",
         symbol: "AERO",
+        amount_type: "usdc_in",
         amount_value: 0,
       }),
     ).toThrow();
@@ -49,33 +59,91 @@ describe("TradeIntentSchema", () => {
       TradeIntentSchema.parse({
         action: "buy",
         symbol: "AERO",
+        amount_type: "usdc_in",
         amount_value: -1,
       }),
     ).toThrow();
   });
 
-  it("accepts sell intents for forward compat", () => {
+  it("accepts a canonical sell intent", () => {
     const parsed = TradeIntentSchema.parse({
       action: "sell",
       symbol: "AERO",
       amount_type: "percent_out",
-      amount_value: 100,
+      amount_value: 50,
     });
     expect(parsed.action).toBe("sell");
+  });
+
+  it("rejects sell percents outside [1, 100]", () => {
+    for (const amount of [0, 101, 150, -10, 33.5]) {
+      expect(() =>
+        TradeIntentSchema.parse({
+          action: "sell",
+          symbol: "AERO",
+          amount_type: "percent_out",
+          amount_value: amount,
+        }),
+      ).toThrow();
+    }
+  });
+
+  it("rejects sells sized in USDC (must be percent_out)", () => {
+    expect(() =>
+      TradeIntentSchema.parse({
+        action: "sell",
+        symbol: "AERO",
+        amount_type: "usdc_in",
+        amount_value: 5,
+      }),
+    ).toThrow();
+  });
+});
+
+describe("CommandIntentSchema", () => {
+  it("accepts a status intent with no other fields", () => {
+    const parsed = CommandIntentSchema.parse({ action: "status" });
+    expect(parsed).toEqual({ action: "status" });
+  });
+
+  it("accepts buy and sell intents via the trade arms", () => {
+    expect(
+      CommandIntentSchema.parse({
+        action: "buy",
+        symbol: "AERO",
+        amount_type: "usdc_in",
+        amount_value: 5,
+      }).action,
+    ).toBe("buy");
+    expect(
+      CommandIntentSchema.parse({
+        action: "sell",
+        symbol: "AERO",
+        amount_type: "percent_out",
+        amount_value: 25,
+      }).action,
+    ).toBe("sell");
+  });
+
+  it("rejects unknown actions", () => {
+    expect(() =>
+      CommandIntentSchema.parse({ action: "cancel", symbol: "AERO" }),
+    ).toThrow();
   });
 });
 
 describe("isUsdcInIntent", () => {
-  it("narrows the type on usdc_in intents", () => {
+  it("narrows the type on buy intents", () => {
     const intent = TradeIntentSchema.parse({
       action: "buy",
       symbol: "AERO",
+      amount_type: "usdc_in",
       amount_value: 1,
     });
     expect(isUsdcInIntent(intent)).toBe(true);
   });
 
-  it("rejects percent_out intents", () => {
+  it("rejects sell intents", () => {
     const intent = TradeIntentSchema.parse({
       action: "sell",
       symbol: "AERO",
@@ -83,5 +151,30 @@ describe("isUsdcInIntent", () => {
       amount_value: 50,
     });
     expect(isUsdcInIntent(intent)).toBe(false);
+  });
+});
+
+describe("isTradeIntent", () => {
+  it("accepts buy and sell intents", () => {
+    expect(
+      isTradeIntent({
+        action: "buy",
+        symbol: "AERO",
+        amount_type: "usdc_in",
+        amount_value: 1,
+      }),
+    ).toBe(true);
+    expect(
+      isTradeIntent({
+        action: "sell",
+        symbol: "AERO",
+        amount_type: "percent_out",
+        amount_value: 50,
+      }),
+    ).toBe(true);
+  });
+
+  it("rejects status intents", () => {
+    expect(isTradeIntent({ action: "status" })).toBe(false);
   });
 });

--- a/lib/execution/intents.ts
+++ b/lib/execution/intents.ts
@@ -1,47 +1,98 @@
 import { z } from "zod";
 
 /**
- * Canonical shape of a parsed Commodus trade command.
+ * Canonical shapes of a parsed Commodus command.
  *
- * This is the contract between the parser (regex pre-filter + future
- * Vercel AI SDK `generateObject` pass) and the rest of the pipeline.
- * The Zod schema is authoritative — everything downstream (policy
- * checks, fee computation, 0x quote, Privy submission) consumes the
- * inferred type `TradeIntent`.
+ * The schemas are the contract between the parser (regex pre-filter +
+ * Vercel AI SDK `generateText` + `Output.object` fallback, see
+ * `lib/execution/parse.ts`) and the rest of the pipeline. Every
+ * downstream consumer (policy checks, fee computation, 0x quote, Privy
+ * submission) imports the inferred types.
  *
- * MVP grammar is buy-only (see `lib/commodus/parser.ts` and the brief
- * on #8), but the schema supports sell now so adding the sell branch
- * in a follow-up doesn't churn callers.
+ * The grammar covers three PRD command shapes (see § Trade Commands):
+ *
+ *   1. `buy N usdc of SYMBOL`     — action=buy,    amount_type=usdc_in,
+ *                                    amount_value ∈ (0, ∞).
+ *   2. `sell N% of SYMBOL`        — action=sell,   amount_type=percent_out,
+ *                                    amount_value ∈ {1, 2, …, 100}.
+ *   3. `status`                   — action=status  (no other fields).
+ *
+ * The discriminated-union shape pins the cross-field constraints per
+ * arm (a buy can never be sized by percent; a sell can never be sized
+ * in USDC). `TradeIntentSchema` is the buy+sell subset so the
+ * execution pipeline's existing callers keep working.
  */
-export const TradeIntentSchema = z.object({
-  action: z.enum(["buy", "sell"]),
-  symbol: z
-    .string()
-    .min(1)
-    .regex(/^[A-Z][A-Z0-9]*$/u, "symbol must be an uppercase ticker"),
-  /**
-   * Buys: USDC-in notional (how many USDC to spend). Sells: USDC-out
-   * notional if the command is sized in USDC. Percent-sell commands
-   * are represented with `amount_type='percent_out'` — not yet wired
-   * through the parser; the schema accepts the shape so the workflow
-   * contract is stable.
-   */
-  amount_type: z.enum(["usdc_in", "percent_out"]).default("usdc_in"),
-  amount_value: z
-    .number()
-    .finite()
-    .positive("amount must be positive"),
+
+const SymbolSchema = z
+  .string()
+  .min(1)
+  .regex(/^[A-Z][A-Z0-9]*$/u, "symbol must be an uppercase ticker");
+
+export const BuyIntentSchema = z.object({
+  action: z.literal("buy"),
+  symbol: SymbolSchema,
+  amount_type: z.literal("usdc_in"),
+  amount_value: z.number().finite().positive("amount must be positive"),
 });
 
-export type TradeIntent = z.infer<typeof TradeIntentSchema>;
+export const SellIntentSchema = z.object({
+  action: z.literal("sell"),
+  symbol: SymbolSchema,
+  amount_type: z.literal("percent_out"),
+  /**
+   * Integer percent in [1, 100]. `0` is meaningless (sells nothing);
+   * values over 100 are impossible (you can't retire more than the
+   * position you hold). The narrow constraint makes the schema the
+   * single source of truth — policy_validate doesn't need to re-check.
+   */
+  amount_value: z.number().int().min(1).max(100),
+});
+
+export const StatusIntentSchema = z.object({
+  action: z.literal("status"),
+});
 
 /**
- * Type guard for `TradeIntent.amount_type === 'usdc_in'`. Keeps callers
- * that care about the buy-only MVP path from re-asserting the literal
- * at every site.
+ * Trade-only union. The execution pipeline (`policy_validate`,
+ * `compute_fee`, `quote_swap`, `submit_swap`, …) consumes this type
+ * because status has no trade to execute.
  */
-export function isUsdcInIntent(intent: TradeIntent): intent is TradeIntent & {
-  amount_type: "usdc_in";
-} {
-  return intent.amount_type === "usdc_in";
+export const TradeIntentSchema = z.discriminatedUnion("action", [
+  BuyIntentSchema,
+  SellIntentSchema,
+]);
+
+/**
+ * Full command union, used at the parser/workflow boundary. The
+ * workflow branches on `intent.action === "status"` before entering
+ * the trade pipeline.
+ */
+export const CommandIntentSchema = z.discriminatedUnion("action", [
+  BuyIntentSchema,
+  SellIntentSchema,
+  StatusIntentSchema,
+]);
+
+export type BuyIntent = z.infer<typeof BuyIntentSchema>;
+export type SellIntent = z.infer<typeof SellIntentSchema>;
+export type StatusIntent = z.infer<typeof StatusIntentSchema>;
+export type TradeIntent = z.infer<typeof TradeIntentSchema>;
+export type CommandIntent = z.infer<typeof CommandIntentSchema>;
+
+/**
+ * Type guard for the USDC-in buy arm. The discriminant is `action`,
+ * so `"buy"` uniquely implies `amount_type === "usdc_in"` via the
+ * schema.
+ */
+export function isUsdcInIntent(intent: TradeIntent): intent is BuyIntent {
+  return intent.action === "buy";
+}
+
+/**
+ * Type guard that narrows a full `CommandIntent` to the trade-only
+ * subset. Callers in the execution pipeline use this to branch off
+ * the status arm before invoking policy/fee/quote logic.
+ */
+export function isTradeIntent(intent: CommandIntent): intent is TradeIntent {
+  return intent.action === "buy" || intent.action === "sell";
 }

--- a/lib/execution/llm-parse.ts
+++ b/lib/execution/llm-parse.ts
@@ -1,0 +1,165 @@
+import "server-only";
+
+import { Output, generateText } from "ai";
+import { z } from "zod";
+
+import {
+  BuyIntentSchema,
+  CommandIntentSchema,
+  SellIntentSchema,
+  StatusIntentSchema,
+  type CommandIntent,
+} from "./intents";
+
+/**
+ * Vercel AI SDK fallback for the Commodus command parser.
+ *
+ * Invoked only when the regex pre-filter in `lib/commodus/parser.ts`
+ * fails with `grammar_error`. Scope is deliberately narrow:
+ *
+ *  1. Map casual phrasings the regex can't handle (`"sell half my aero"`)
+ *     to the canonical `CommandIntent` shape.
+ *  2. Emit `status` intents for the no-argument status command.
+ *  3. Signal "not a command" when the cast text is conversational or
+ *     otherwise unparsable — we add a fourth arm (`{ action: "invalid" }`)
+ *     to the schema the LLM sees so it has a structural way to say "I
+ *     can't parse this" rather than inventing a trade.
+ *
+ * Asset-whitelist and size enforcement stay in `policy_validate`. The
+ * LLM is explicitly instructed not to introduce symbols or amounts
+ * that aren't present in the user text.
+ *
+ * Retry semantics: one retry (total two attempts) on any failure
+ * (gateway error, schema validation error, or explicit `invalid`
+ * result). A second failure returns `{ ok: false, reason: "grammar" }`
+ * so the workflow publishes the templated grammar rejection once and
+ * marks `cast_commands.error_reason='grammar'`.
+ *
+ * Routing: defaults to `openai/gpt-5.4-mini` via the Vercel AI Gateway
+ * (global default provider when importing `model: "openai/..."` from
+ * `ai`). Model selection is a string to avoid hardcoding a provider
+ * SDK import — the gateway handles routing, failover, and auth.
+ */
+
+/**
+ * Model identifier sent to the Vercel AI Gateway. `openai/gpt-5.4-mini`
+ * is the cheapest OpenAI model with reliable JSON-schema adherence as
+ * of the issue-9 ship date. Override via `opts.model` for tests or
+ * provider experiments.
+ */
+export const DEFAULT_COMMAND_PARSER_MODEL = "openai/gpt-5.4-mini";
+
+/**
+ * Schema sent to the LLM. Includes an `invalid` arm so the model can
+ * surface "no command present" without having to throw. The outer
+ * helper collapses `invalid` into `{ ok: false, reason: "grammar" }`.
+ */
+const InvalidIntentSchema = z.object({
+  action: z.literal("invalid"),
+});
+
+const LlmCommandIntentSchema = z.discriminatedUnion("action", [
+  BuyIntentSchema,
+  SellIntentSchema,
+  StatusIntentSchema,
+  InvalidIntentSchema,
+]);
+
+export type LlmCommandIntent = z.infer<typeof LlmCommandIntentSchema>;
+
+export type LlmParseResult =
+  | { ok: true; intent: CommandIntent }
+  | { ok: false; reason: "grammar" };
+
+const SYSTEM_PROMPT = `You are the grammar validator for the Commodus Roman-arena trading bot.
+
+Your only job is to classify a single cast text into exactly one of four shapes:
+
+  1. buy:    { "action": "buy",    "symbol": "<TICKER>",   "amount_type": "usdc_in",     "amount_value": <positive number> }
+  2. sell:   { "action": "sell",   "symbol": "<TICKER>",   "amount_type": "percent_out", "amount_value": <integer 1..100> }
+  3. status: { "action": "status" }
+  4. invalid:{ "action": "invalid" }
+
+Canonical PRD grammar:
+  - "buy N usdc of SYMBOL"       e.g. "buy 5 usdc of aero"
+  - "sell N% of SYMBOL"          e.g. "sell 50% of aero"
+  - "status"
+
+Casual phrasings you must accept (examples — not exhaustive):
+  - "buy $10 aero"                        → buy,  symbol=AERO, amount_value=10
+  - "@commodus grab 2 usdc worth of aero" → buy,  symbol=AERO, amount_value=2
+  - "sell half my aero"                   → sell, symbol=AERO, amount_value=50
+  - "sell 25% of my aero"                 → sell, symbol=AERO, amount_value=25
+  - "dump all my aero"                    → sell, symbol=AERO, amount_value=100
+  - "status"                              → status
+  - "@commodus status"                    → status
+  - "what's my rank?"                     → status
+  - "show my portfolio"                   → status
+
+Normalization rules:
+  - Input is already lowercased and trimmed.
+  - Strip any leading mention token like "@commodus" or "@commo".
+  - Return symbols UPPERCASED, shape /^[A-Z][A-Z0-9]*$/.
+
+Hard rules — violations must resolve to { "action": "invalid" }:
+  - Never invent a symbol that is not present in the user text.
+  - Never invent an amount that is not present or implied by the user text.
+    ("half" → 50, "all" → 100, "a quarter" → 25 are allowed inferences.)
+  - Never return a buy without a USDC amount.
+  - Never return a sell without a percent (or an implied percent from half/all/etc.).
+  - Never produce a command from casts that contain no trade/status verb
+    ("hello commodus", "gm", "lol" → invalid).
+  - Never return amount_type: "usdc_in" for sells, or "percent_out" for buys.
+
+You must not output anything outside the schema. No free-form text.`;
+
+export type ParseWithLlmOptions = {
+  /** AI Gateway model identifier. */
+  model?: string;
+  /**
+   * Maximum number of retries after the first failure. Defaults to 1
+   * (AC § retry-once-then-hard-fail). Set to 0 in tests that want to
+   * pin single-attempt behavior.
+   */
+  maxRetries?: number;
+  /**
+   * Injected for tests. Defaults to `generateText` from `ai`. The
+   * function-typed seam lets the test suite mock without `vi.mock`.
+   */
+  generate?: typeof generateText;
+};
+
+export async function parseCommandIntentWithLlm(
+  text: string,
+  opts: ParseWithLlmOptions = {},
+): Promise<LlmParseResult> {
+  const model = opts.model ?? DEFAULT_COMMAND_PARSER_MODEL;
+  const maxRetries = opts.maxRetries ?? 1;
+  const generate = opts.generate ?? generateText;
+  const totalAttempts = 1 + Math.max(0, maxRetries);
+
+  for (let attempt = 0; attempt < totalAttempts; attempt++) {
+    try {
+      const result = await generate({
+        model,
+        output: Output.object({ schema: LlmCommandIntentSchema }),
+        system: SYSTEM_PROMPT,
+        prompt: `Cast text (already lowercased + mention-stripped): ${JSON.stringify(text)}`,
+      });
+
+      // `result.output` is typed by `Output.object`, but the SDK does
+      // not validate against our schema end-to-end — we re-validate so
+      // a provider that silently drops fields lands in the retry loop.
+      const parsed = LlmCommandIntentSchema.safeParse(result.output);
+      if (!parsed.success) continue;
+      if (parsed.data.action === "invalid") continue;
+
+      return { ok: true, intent: parsed.data };
+    } catch {
+      // Swallow — any gateway or schema error burns one attempt and
+      // falls through to the retry or hard-fail below.
+    }
+  }
+
+  return { ok: false, reason: "grammar" };
+}

--- a/lib/execution/parse.ts
+++ b/lib/execution/parse.ts
@@ -1,31 +1,39 @@
 import "server-only";
 
 import {
+  normalizeCommandText,
   parseCommand,
   type ParseResult,
 } from "@/lib/commodus/parser";
 
-import { TradeIntentSchema, type TradeIntent } from "./intents";
+import type { CommandIntent } from "./intents";
+import {
+  parseCommandIntentWithLlm,
+  type ParseWithLlmOptions,
+} from "./llm-parse";
 
 /**
- * Parser step entry point for the durable pipeline.
+ * Two-stage parser for the `parse_command` workflow step.
  *
- * Today this is a regex pre-filter only. Future-compat: if the regex
- * does not match, fall through to a Vercel AI SDK `generateObject`
- * call against the AI Gateway with `TradeIntentSchema`. That fallback
- * is intentionally stubbed for now — the tradeoff is observability:
- * the regex handles 95% of canonical `buy N usdc of SYMBOL` phrasing,
- * and falling back for the 5% of casual grammar costs latency + AI
- * spend that we'd rather not pay before the pipeline is seasoned.
+ * Stage 1 — regex pre-filter (`lib/commodus/parser.ts`).
+ *   The canonical AERO buy path (`buy N usdc of aero`) is matched
+ *   without any LLM call and returns a buy `CommandIntent` directly.
+ *   Grammar mismatches fall through to Stage 2. Structurally-valid
+ *   buys that fail the hardcoded whitelist / size heuristics
+ *   (`asset_error`, `oversize_error`) short-circuit here — the
+ *   parser is the right layer to surface "you typed a real command
+ *   but it's not tradable", and `policy_validate` will redundantly
+ *   reject the same cases for LLM-parsed variants.
  *
- * The parse result is normalized to one of two shapes the workflow
- * can switch on:
+ * Stage 2 — Vercel AI SDK fallback (`llm-parse.ts`).
+ *   Handles casual phrasings for buy/sell/status that the regex
+ *   cannot: `"sell half my aero"`, `"@commodus status"`,
+ *   `"what's my rank"`, etc. Returns a `CommandIntent` or signals
+ *   `grammar` after retry-once.
  *
- *   - `{ ok: true, intent }` — a validated `TradeIntent` (Zod-parsed,
- *     ready for policy + fee + quote steps).
- *   - `{ ok: false, reason }` — a rejection reason matching the
- *     `lib/commodus/templates` catalog so outcome-reply wiring is
- *     deterministic.
+ * The result is a narrow `{ ok: true, intent } | { ok: false, reason }`
+ * shape. Callers (the workflow) switch on `reason` for templated
+ * outcome replies.
  */
 
 export type ParseReason =
@@ -33,22 +41,40 @@ export type ParseReason =
   | "asset_error"
   | "oversize_error";
 
-export type ParseOutcome =
-  | { ok: true; intent: TradeIntent }
-  | { ok: false; reason: ParseReason; raw: ParseResult };
+export type ParseCommandOutcome =
+  | { ok: true; intent: CommandIntent }
+  | { ok: false; reason: ParseReason; raw?: ParseResult };
 
-export function parseTradeCommand(text: string): ParseOutcome {
-  const result = parseCommand(text);
+export type ParseCommandOptions = {
+  /** Passthrough for the LLM fallback (injected in tests). */
+  llm?: ParseWithLlmOptions;
+};
 
-  if (result.kind === "ok") {
-    const intent = TradeIntentSchema.parse({
-      action: result.action,
-      symbol: result.symbol,
-      amount_type: "usdc_in",
-      amount_value: result.amount,
-    });
-    return { ok: true, intent };
+export async function parseCommandIntent(
+  text: string,
+  opts: ParseCommandOptions = {},
+): Promise<ParseCommandOutcome> {
+  const regex = parseCommand(text);
+
+  if (regex.kind === "ok") {
+    return {
+      ok: true,
+      intent: {
+        action: "buy",
+        symbol: regex.symbol,
+        amount_type: "usdc_in",
+        amount_value: regex.amount,
+      },
+    };
   }
 
-  return { ok: false, reason: result.kind, raw: result };
+  if (regex.kind === "asset_error" || regex.kind === "oversize_error") {
+    return { ok: false, reason: regex.kind, raw: regex };
+  }
+
+  const normalized = normalizeCommandText(text);
+  const llm = await parseCommandIntentWithLlm(normalized, opts.llm);
+  if (llm.ok) return { ok: true, intent: llm.intent };
+
+  return { ok: false, reason: "grammar_error", raw: regex };
 }

--- a/lib/execution/templates.ts
+++ b/lib/execution/templates.ts
@@ -54,3 +54,19 @@ export const POLICY_REJECTION_COPY: Record<PolicyRejectionReason, string> = {
   wallet_cap_usdc:
     "Order denied. Thy arena coffers have reached their cap. Withdraw before deploying more.",
 };
+
+/**
+ * Non-policy templated rejection copy used by the workflow for states
+ * that aren't a `PolicyRejectionReason` — features that have passed
+ * every gate but are not yet fully wired.
+ *
+ * TODO(#10): remove `sell_not_yet_supported` once sell execution is
+ *            implemented; sells should then flow through the full
+ *            pipeline like buys.
+ */
+export const HANDOFF_REJECTION_COPY = {
+  sell_not_yet_supported:
+    "The decree is understood, gladiator, but the arena does not yet accept sales. Return when the forges of Rome are ready.",
+} as const satisfies Record<string, string>;
+
+export type HandoffRejectionReason = keyof typeof HANDOFF_REJECTION_COPY;

--- a/lib/workflows/commodus-command.ts
+++ b/lib/workflows/commodus-command.ts
@@ -3,7 +3,10 @@ import { parseUnits, type Hex } from "viem";
 
 import { USDC_BASE_ADDRESS, USDC_DECIMALS } from "@/lib/chain/addresses";
 import { basePublicClient } from "@/lib/chain/client";
-import { buildAcceptedReply } from "@/lib/commodus/templates";
+import {
+  REJECTION_REPLIES,
+  buildAcceptedReply,
+} from "@/lib/commodus/templates";
 import { env } from "@/lib/env";
 import { MissingSignerError } from "@/lib/neynar";
 import {
@@ -23,12 +26,9 @@ import {
   submitFeeTransfer,
   OperatorTreasuryNotConfiguredError,
 } from "@/lib/execution/fee-transfer";
-import {
-  computeSwapFeeUsdc,
-  netBuyNotionalUsdc,
-} from "@/lib/execution/fees";
+import { computeSwapFeeUsdc } from "@/lib/execution/fees";
 import { deriveExecutionId } from "@/lib/execution/ids";
-import { parseTradeCommand } from "@/lib/execution/parse";
+import { parseCommandIntent } from "@/lib/execution/parse";
 import { validatePolicy, type PolicyContext } from "@/lib/execution/policy";
 import { publishReplyOnce } from "@/lib/execution/reply-guard";
 import {
@@ -38,9 +38,10 @@ import {
 import {
   buildIntentReply,
   buildOutcomeReply,
+  HANDOFF_REJECTION_COPY,
   POLICY_REJECTION_COPY,
 } from "@/lib/execution/templates";
-import type { TradeIntent } from "@/lib/execution/intents";
+import type { CommandIntent, TradeIntent } from "@/lib/execution/intents";
 
 /**
  * Payload forwarded from the Neynar `cast.created` webhook. Narrow by
@@ -83,16 +84,24 @@ export async function handleCommodusCommand(ctx: CommandContext) {
 
   const parseOutcome = await parseStep(ctx.text);
   if (!parseOutcome.ok) {
-    await markRejected(ctx.castHash, parseOutcome.reason);
-    await publishOutcomeReply(
-      ctx.castHash,
-      buildOutcomeReply({ kind: "failure", reason: parseOutcome.reason }),
-    );
-    return { status: "rejected" as const, reason: parseOutcome.reason };
+    const rejection = parseRejectionFor(parseOutcome.reason);
+    await markRejected(ctx.castHash, rejection.errorReason);
+    await publishOutcomeReply(ctx.castHash, rejection.reply);
+    return { status: "rejected" as const, reason: rejection.errorReason };
   }
 
-  const intent = parseOutcome.intent;
+  const commandIntent = parseOutcome.intent;
   await markStatus(ctx.castHash, "parsed");
+
+  // Status branch — short-circuit before the entire trade pipeline.
+  // Real reply behavior (Snap card + rank) is issue #13; this issue
+  // only wires the no-op handoff point.
+  if (commandIntent.action === "status") {
+    await handleStatusNoop({ castHash: ctx.castHash });
+    return { status: "status_ack" as const };
+  }
+
+  const intent: TradeIntent = commandIntent;
 
   const walletLookup = await resolveArenaWallet(ctx.authorFid);
   if (!walletLookup) {
@@ -122,15 +131,31 @@ export async function handleCommodusCommand(ctx: CommandContext) {
 
   await markStatus(ctx.castHash, "validated");
 
+  // Sell handoff — #9 reaches `policy_validate` and stops here. Full
+  // sell execution (quote, submit, FIFO lot consumption, realized PnL)
+  // is issue #10. Leaving the `TODO(#10)` markers below so the pickup
+  // PR knows what to remove.
+  if (intent.action === "sell") {
+    await markRejected(ctx.castHash, "sell_not_yet_supported");
+    await publishOutcomeReply(
+      ctx.castHash,
+      HANDOFF_REJECTION_COPY.sell_not_yet_supported,
+    );
+    return {
+      status: "rejected" as const,
+      reason: "sell_not_yet_supported" as const,
+    };
+  }
+
+  // `intent` is now narrowed to `BuyIntent` — sells branched out above
+  // and status branched out before wallet lookup.
   const feeUsdc = await computeFee({
     notionalUsdc: intent.amount_value,
     swapFeeBps: policy.context.policy.swapFeeBps,
     swapFeeMinUsdc: policy.context.policy.swapFeeMinUsdc,
   });
 
-  const netNotional = intent.action === "buy"
-    ? Math.max(intent.amount_value - feeUsdc, 0)
-    : intent.amount_value;
+  const netNotional = Math.max(intent.amount_value - feeUsdc, 0);
 
   if (netNotional <= 0) {
     await markRejected(ctx.castHash, "max_trade_usdc");
@@ -271,14 +296,37 @@ async function loadCommand(castHash: string): Promise<LoadedCommand> {
 async function parseStep(
   text: string,
 ): Promise<
-  | { ok: true; intent: TradeIntent }
+  | { ok: true; intent: CommandIntent }
   | { ok: false; reason: string }
 > {
   "use step";
 
-  const result = parseTradeCommand(text);
+  const result = await parseCommandIntent(text);
   if (result.ok) return { ok: true, intent: result.intent };
   return { ok: false, reason: result.reason };
+}
+
+// ---------------------------------------------------------------------------
+// Step: handle_status_noop
+//
+// Placeholder for the status command. Marks the cast terminal so
+// replays don't re-enter the workflow; the real Snap-card reply lives
+// in issue #13.
+//
+// TODO(#13): replace this with a real status reply step that builds
+//            the portfolio summary + rank and publishes an outcome
+//            cast. The terminal status marker here becomes the
+//            `status_ack` -> `executed` transition at that point.
+// ---------------------------------------------------------------------------
+
+async function handleStatusNoop(params: { castHash: string }): Promise<void> {
+  "use step";
+
+  await supabaseAdmin
+    .from("cast_commands")
+    .update({ status: "executed" })
+    .eq("cast_hash", params.castHash)
+    .not("status", "in", "(executed,failed,rejected)");
 }
 
 // ---------------------------------------------------------------------------
@@ -756,4 +804,35 @@ function isUniqueViolation(error: unknown): boolean {
     "code" in error &&
     (error as { code?: unknown }).code === "23505"
   );
+}
+
+/**
+ * Maps a parser rejection reason onto the templated Commodus reply +
+ * the `cast_commands.error_reason` string. Parse-level rejections use
+ * the voice catalog in `lib/commodus/templates.ts`, not the generic
+ * execution outcome copy — the grammar rejection text is pinned to
+ * the PRD § Commodus Voice exemplar.
+ */
+function parseRejectionFor(reason: string): {
+  errorReason: string;
+  reply: string;
+} {
+  if (reason === "grammar_error") {
+    return { errorReason: "grammar", reply: REJECTION_REPLIES.grammar };
+  }
+  if (reason === "asset_error") {
+    return {
+      errorReason: "non_whitelisted_token",
+      reply: REJECTION_REPLIES.non_whitelisted_token,
+    };
+  }
+  if (reason === "oversize_error") {
+    return { errorReason: "oversize", reply: REJECTION_REPLIES.oversize };
+  }
+  // Defensive: unknown reasons fall through to the generic outcome copy
+  // so a future parser shape doesn't silently drop the reply.
+  return {
+    errorReason: reason,
+    reply: buildOutcomeReply({ kind: "failure", reason }),
+  };
 }

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@upstash/redis": "^1.35.7",
     "@vercel/analytics": "^2.0.1",
     "@vercel/speed-insights": "^2.0.0",
+    "ai": "^6.0.168",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,10 +49,13 @@ importers:
         version: 1.35.7
       '@vercel/analytics':
         specifier: ^2.0.1
-        version: 2.0.1(next@16.0.7(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react@19.2.1)
+        version: 2.0.1(next@16.0.7(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react@19.2.1)
       '@vercel/speed-insights':
         specifier: ^2.0.0
-        version: 2.0.0(next@16.0.7(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react@19.2.1)
+        version: 2.0.0(next@16.0.7(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react@19.2.1)
+      ai:
+        specifier: ^6.0.168
+        version: 6.0.168(zod@4.1.13)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -76,7 +79,7 @@ importers:
         version: 1.14.0
       next:
         specifier: 16.0.7
-        version: 16.0.7(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+        version: 16.0.7(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       next-secure-headers:
         specifier: ^2.2.0
         version: 2.2.0
@@ -103,7 +106,7 @@ importers:
         version: 2.19.5(@tanstack/query-core@5.90.12)(@tanstack/react-query@5.90.12(react@19.2.1))(@types/react@19.2.7)(@upstash/redis@1.35.7)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.13))(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.1)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.41.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.1.13))(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.1.13)
       workflow:
         specifier: ^4.2.4
-        version: 4.2.4(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.19(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.17))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.17))(@swc/helpers@0.5.17)(next@16.0.7(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(typescript@5.9.3)
+        version: 4.2.4(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.19(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.0)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.17))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.17))(@swc/helpers@0.5.17)(next@16.0.7(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(typescript@5.9.3)
       zod:
         specifier: ^4.1.13
         version: 4.1.13
@@ -146,6 +149,22 @@ packages:
 
   '@adraffy/ens-normalize@1.11.1':
     resolution: {integrity: sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==}
+
+  '@ai-sdk/gateway@3.0.104':
+    resolution: {integrity: sha512-ZKX5n74io8VIRlhIMSLWVlvT3sXC8Z7cZ9GHuWBWZDVi96+62AIsWuLGvMfcBA1STYuSoDrp6rIziZmvrTq0TA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider-utils@4.0.23':
+    resolution: {integrity: sha512-z8GlDaCmRSDlqkMF2f4/RFgWxdarvIbyuk+m6WXT1LYgsnGiXRJGTD2Z1+SDl3LqtFuRtGX1aghYvQLoHL/9pg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider@3.0.8':
+    resolution: {integrity: sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==}
+    engines: {node: '>=18'}
 
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
@@ -1049,6 +1068,10 @@ packages:
     resolution: {integrity: sha512-5N/X/FzlJaYfpaHwDC0YHzOzKDWa41s9t+4FpCDu4f9OMReds4JeNBaaWk9rlIzdKjh2M6AC5Q18ORfECRkHGA==}
     engines: {node: '>=18.0.0'}
 
+  '@opentelemetry/api@1.9.0':
+    resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
+    engines: {node: '>=8.0.0'}
+
   '@paulmillr/qr@0.2.1':
     resolution: {integrity: sha512-IHnV6A+zxU7XwmKFinmYjUcwlyK9+xkG3/s9KcQhI9BjQKycrJ1JRO+FbNYPwZiPKW3je/DR0k7w8/gLa5eaxQ==}
     deprecated: 'The package is now available as "qr": npm install qr'
@@ -1776,6 +1799,9 @@ packages:
 
   '@standard-schema/spec@1.0.0':
     resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==}
+
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
   '@supabase/auth-js@2.103.3':
     resolution: {integrity: sha512-SMDJ4vg5jLXNEHdhN4J4ujSb203WangbDw1n3VaARH0ZqM51E6lJnoUAHlpQU9N7SzP0hfgghA9IvT8c7tGRfg==}
@@ -2567,6 +2593,12 @@ packages:
   agentkeepalive@4.6.0:
     resolution: {integrity: sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==}
     engines: {node: '>= 8.0.0'}
+
+  ai@6.0.168:
+    resolution: {integrity: sha512-2HqCJuO+1V2aV7vfYs5LFEUfxbkGX+5oa54q/gCCTL7KLTdbxcCu5D7TdLA5kwsrs3Szgjah9q6D9tpjHM3hUQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
 
   ajv@6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
@@ -3508,6 +3540,10 @@ packages:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
 
+  eventsource-parser@3.0.8:
+    resolution: {integrity: sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==}
+    engines: {node: '>=18.0.0'}
+
   execa@8.0.1:
     resolution: {integrity: sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==}
     engines: {node: '>=16.17'}
@@ -4199,6 +4235,9 @@ packages:
 
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+
+  json-schema@0.4.0:
+    resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
 
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
@@ -6149,6 +6188,24 @@ snapshots:
 
   '@adraffy/ens-normalize@1.11.1': {}
 
+  '@ai-sdk/gateway@3.0.104(zod@4.1.13)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.8
+      '@ai-sdk/provider-utils': 4.0.23(zod@4.1.13)
+      '@vercel/oidc': 3.2.0
+      zod: 4.1.13
+
+  '@ai-sdk/provider-utils@4.0.23(zod@4.1.13)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.8
+      '@standard-schema/spec': 1.1.0
+      eventsource-parser: 3.0.8
+      zod: 4.1.13
+
+  '@ai-sdk/provider@3.0.8':
+    dependencies:
+      json-schema: 0.4.0
+
   '@alloc/quick-lru@5.2.0': {}
 
   '@aws-crypto/sha256-browser@5.2.0':
@@ -7211,6 +7268,8 @@ snapshots:
   '@oclif/plugin-help@6.2.37':
     dependencies:
       '@oclif/core': 4.8.1
+
+  '@opentelemetry/api@1.9.0': {}
 
   '@paulmillr/qr@0.2.1': {}
 
@@ -8372,6 +8431,8 @@ snapshots:
 
   '@standard-schema/spec@1.0.0': {}
 
+  '@standard-schema/spec@1.1.0': {}
+
   '@supabase/auth-js@2.103.3':
     dependencies:
       tslib: 2.8.1
@@ -8690,9 +8751,9 @@ snapshots:
     dependencies:
       uncrypto: 0.1.3
 
-  '@vercel/analytics@2.0.1(next@16.0.7(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react@19.2.1)':
+  '@vercel/analytics@2.0.1(next@16.0.7(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react@19.2.1)':
     optionalDependencies:
-      next: 16.0.7(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      next: 16.0.7(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       react: 19.2.1
 
   '@vercel/cli-auth@0.0.1':
@@ -8717,9 +8778,9 @@ snapshots:
       mixpart: 0.0.5
       picocolors: 1.1.1
 
-  '@vercel/speed-insights@2.0.0(next@16.0.7(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react@19.2.1)':
+  '@vercel/speed-insights@2.0.0(next@16.0.7(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react@19.2.1)':
     optionalDependencies:
-      next: 16.0.7(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      next: 16.0.7(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       react: 19.2.1
 
   '@vitest/expect@3.2.4':
@@ -9385,13 +9446,13 @@ snapshots:
       '@walletconnect/window-getters': 1.0.1
       tslib: 1.14.1
 
-  '@workflow/astro@4.0.4(@swc/helpers@0.5.17)':
+  '@workflow/astro@4.0.4(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.17)':
     dependencies:
       '@swc/core': 1.15.3(@swc/helpers@0.5.17)
-      '@workflow/builders': 4.0.5(@swc/helpers@0.5.17)
-      '@workflow/rollup': 4.0.4(@swc/helpers@0.5.17)
+      '@workflow/builders': 4.0.5(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.17)
+      '@workflow/rollup': 4.0.4(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.17)
       '@workflow/swc-plugin': 4.1.0(@swc/core@1.15.3(@swc/helpers@0.5.17))
-      '@workflow/vite': 4.0.4(@swc/helpers@0.5.17)
+      '@workflow/vite': 4.0.4(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.17)
       exsolve: 1.0.8
       pathe: 2.0.3
     transitivePeerDependencies:
@@ -9400,10 +9461,10 @@ snapshots:
       - aws-crt
       - supports-color
 
-  '@workflow/builders@4.0.5(@swc/helpers@0.5.17)':
+  '@workflow/builders@4.0.5(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.17)':
     dependencies:
       '@swc/core': 1.15.3(@swc/helpers@0.5.17)
-      '@workflow/core': 4.2.4
+      '@workflow/core': 4.2.4(@opentelemetry/api@1.9.0)
       '@workflow/errors': 4.1.1
       '@workflow/swc-plugin': 4.1.0(@swc/core@1.15.3(@swc/helpers@0.5.17))
       '@workflow/utils': 4.1.1
@@ -9420,21 +9481,21 @@ snapshots:
       - aws-crt
       - supports-color
 
-  '@workflow/cli@4.2.4(@swc/helpers@0.5.17)':
+  '@workflow/cli@4.2.4(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.17)':
     dependencies:
       '@oclif/core': 4.8.1
       '@oclif/plugin-help': 6.2.37
       '@swc/core': 1.15.3(@swc/helpers@0.5.17)
       '@vercel/cli-auth': 0.0.1
-      '@workflow/builders': 4.0.5(@swc/helpers@0.5.17)
-      '@workflow/core': 4.2.4
+      '@workflow/builders': 4.0.5(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.17)
+      '@workflow/core': 4.2.4(@opentelemetry/api@1.9.0)
       '@workflow/errors': 4.1.1
       '@workflow/swc-plugin': 4.1.0(@swc/core@1.15.3(@swc/helpers@0.5.17))
       '@workflow/utils': 4.1.1
       '@workflow/web': 4.1.5
       '@workflow/world': 4.1.1(zod@4.3.6)
-      '@workflow/world-local': 4.1.1
-      '@workflow/world-vercel': 4.1.2
+      '@workflow/world-local': 4.1.1(@opentelemetry/api@1.9.0)
+      '@workflow/world-vercel': 4.1.2(@opentelemetry/api@1.9.0)
       boxen: 8.0.1
       builtin-modules: 5.0.0
       chalk: 5.6.2
@@ -9458,7 +9519,7 @@ snapshots:
       - aws-crt
       - supports-color
 
-  '@workflow/core@4.2.4':
+  '@workflow/core@4.2.4(@opentelemetry/api@1.9.0)':
     dependencies:
       '@aws-sdk/credential-provider-web-identity': 3.972.13
       '@jridgewell/trace-mapping': 0.3.31
@@ -9469,8 +9530,8 @@ snapshots:
       '@workflow/serde': 4.1.1
       '@workflow/utils': 4.1.1
       '@workflow/world': 4.1.1(zod@4.3.6)
-      '@workflow/world-local': 4.1.1
-      '@workflow/world-vercel': 4.1.2
+      '@workflow/world-local': 4.1.1(@opentelemetry/api@1.9.0)
+      '@workflow/world-vercel': 4.1.2(@opentelemetry/api@1.9.0)
       debug: 4.4.3(supports-color@8.1.1)
       devalue: 5.6.3
       ms: 2.1.3
@@ -9479,6 +9540,8 @@ snapshots:
       semver: 7.7.4
       ulid: 3.0.2
       zod: 4.3.6
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.0
     transitivePeerDependencies:
       - aws-crt
       - supports-color
@@ -9488,13 +9551,13 @@ snapshots:
       '@workflow/utils': 4.1.1
       ms: 2.1.3
 
-  '@workflow/nest@0.0.4(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.19(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.17))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.17))(@swc/helpers@0.5.17)':
+  '@workflow/nest@0.0.4(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.19(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.0)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.17))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.17))(@swc/helpers@0.5.17)':
     dependencies:
       '@nestjs/common': 11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@nestjs/core': 11.1.19(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@swc/cli': 0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.17))(chokidar@5.0.0)
       '@swc/core': 1.15.3(@swc/helpers@0.5.17)
-      '@workflow/builders': 4.0.5(@swc/helpers@0.5.17)
+      '@workflow/builders': 4.0.5(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.17)
       '@workflow/swc-plugin': 4.1.0(@swc/core@1.15.3(@swc/helpers@0.5.17))
       pathe: 2.0.3
     transitivePeerDependencies:
@@ -9503,30 +9566,30 @@ snapshots:
       - aws-crt
       - supports-color
 
-  '@workflow/next@4.0.5(@swc/helpers@0.5.17)(next@16.0.7(react-dom@19.2.1(react@19.2.1))(react@19.2.1))':
+  '@workflow/next@4.0.5(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.17)(next@16.0.7(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))':
     dependencies:
       '@swc/core': 1.15.3(@swc/helpers@0.5.17)
-      '@workflow/builders': 4.0.5(@swc/helpers@0.5.17)
-      '@workflow/core': 4.2.4
+      '@workflow/builders': 4.0.5(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.17)
+      '@workflow/core': 4.2.4(@opentelemetry/api@1.9.0)
       '@workflow/swc-plugin': 4.1.0(@swc/core@1.15.3(@swc/helpers@0.5.17))
       semver: 7.7.4
       watchpack: 2.5.1
     optionalDependencies:
-      next: 16.0.7(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      next: 16.0.7(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
     transitivePeerDependencies:
       - '@opentelemetry/api'
       - '@swc/helpers'
       - aws-crt
       - supports-color
 
-  '@workflow/nitro@4.0.5(@swc/helpers@0.5.17)':
+  '@workflow/nitro@4.0.5(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.17)':
     dependencies:
       '@swc/core': 1.15.3(@swc/helpers@0.5.17)
-      '@workflow/builders': 4.0.5(@swc/helpers@0.5.17)
-      '@workflow/core': 4.2.4
-      '@workflow/rollup': 4.0.4(@swc/helpers@0.5.17)
+      '@workflow/builders': 4.0.5(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.17)
+      '@workflow/core': 4.2.4(@opentelemetry/api@1.9.0)
+      '@workflow/rollup': 4.0.4(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.17)
       '@workflow/swc-plugin': 4.1.0(@swc/core@1.15.3(@swc/helpers@0.5.17))
-      '@workflow/vite': 4.0.4(@swc/helpers@0.5.17)
+      '@workflow/vite': 4.0.4(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.17)
       exsolve: 1.0.8
       pathe: 2.0.3
     transitivePeerDependencies:
@@ -9535,10 +9598,10 @@ snapshots:
       - aws-crt
       - supports-color
 
-  '@workflow/nuxt@4.0.5(@swc/helpers@0.5.17)':
+  '@workflow/nuxt@4.0.5(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.17)':
     dependencies:
       '@nuxt/kit': 4.4.2
-      '@workflow/nitro': 4.0.5(@swc/helpers@0.5.17)
+      '@workflow/nitro': 4.0.5(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.17)
     transitivePeerDependencies:
       - '@opentelemetry/api'
       - '@swc/helpers'
@@ -9546,10 +9609,10 @@ snapshots:
       - magicast
       - supports-color
 
-  '@workflow/rollup@4.0.4(@swc/helpers@0.5.17)':
+  '@workflow/rollup@4.0.4(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.17)':
     dependencies:
       '@swc/core': 1.15.3(@swc/helpers@0.5.17)
-      '@workflow/builders': 4.0.5(@swc/helpers@0.5.17)
+      '@workflow/builders': 4.0.5(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.17)
       '@workflow/swc-plugin': 4.1.0(@swc/core@1.15.3(@swc/helpers@0.5.17))
       exsolve: 1.0.7
     transitivePeerDependencies:
@@ -9560,13 +9623,13 @@ snapshots:
 
   '@workflow/serde@4.1.1': {}
 
-  '@workflow/sveltekit@4.0.4(@swc/helpers@0.5.17)':
+  '@workflow/sveltekit@4.0.4(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.17)':
     dependencies:
       '@swc/core': 1.15.3(@swc/helpers@0.5.17)
-      '@workflow/builders': 4.0.5(@swc/helpers@0.5.17)
-      '@workflow/rollup': 4.0.4(@swc/helpers@0.5.17)
+      '@workflow/builders': 4.0.5(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.17)
+      '@workflow/rollup': 4.0.4(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.17)
       '@workflow/swc-plugin': 4.1.0(@swc/core@1.15.3(@swc/helpers@0.5.17))
-      '@workflow/vite': 4.0.4(@swc/helpers@0.5.17)
+      '@workflow/vite': 4.0.4(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.17)
       exsolve: 1.0.8
       fs-extra: 11.3.4
       pathe: 2.0.3
@@ -9588,9 +9651,9 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
-  '@workflow/vite@4.0.4(@swc/helpers@0.5.17)':
+  '@workflow/vite@4.0.4(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.17)':
     dependencies:
-      '@workflow/builders': 4.0.5(@swc/helpers@0.5.17)
+      '@workflow/builders': 4.0.5(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.17)
     transitivePeerDependencies:
       - '@opentelemetry/api'
       - '@swc/helpers'
@@ -9603,7 +9666,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@workflow/world-local@4.1.1':
+  '@workflow/world-local@4.1.1(@opentelemetry/api@1.9.0)':
     dependencies:
       '@vercel/queue': 0.1.4
       '@workflow/errors': 4.1.1
@@ -9613,8 +9676,10 @@ snapshots:
       ulid: 3.0.2
       undici: 7.22.0
       zod: 4.3.6
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.0
 
-  '@workflow/world-vercel@4.1.2':
+  '@workflow/world-vercel@4.1.2(@opentelemetry/api@1.9.0)':
     dependencies:
       '@vercel/oidc': 3.2.0
       '@vercel/queue': 0.1.4
@@ -9623,6 +9688,8 @@ snapshots:
       cbor-x: 1.6.0
       undici: 7.22.0
       zod: 4.3.6
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.0
 
   '@workflow/world@4.1.1(zod@4.3.6)':
     dependencies:
@@ -9774,6 +9841,14 @@ snapshots:
   agentkeepalive@4.6.0:
     dependencies:
       humanize-ms: 1.2.1
+
+  ai@6.0.168(zod@4.1.13):
+    dependencies:
+      '@ai-sdk/gateway': 3.0.104(zod@4.1.13)
+      '@ai-sdk/provider': 3.0.8
+      '@ai-sdk/provider-utils': 4.0.23(zod@4.1.13)
+      '@opentelemetry/api': 1.9.0
+      zod: 4.1.13
 
   ajv@6.12.6:
     dependencies:
@@ -10880,6 +10955,8 @@ snapshots:
 
   events@3.3.0: {}
 
+  eventsource-parser@3.0.8: {}
+
   execa@8.0.1:
     dependencies:
       cross-spawn: 7.0.6
@@ -11613,6 +11690,8 @@ snapshots:
 
   json-schema-traverse@0.4.1: {}
 
+  json-schema@0.4.0: {}
+
   json-stable-stringify-without-jsonify@1.0.1: {}
 
   json-stringify-safe@5.0.1: {}
@@ -11840,7 +11919,7 @@ snapshots:
 
   next-secure-headers@2.2.0: {}
 
-  next@16.0.7(react-dom@19.2.1(react@19.2.1))(react@19.2.1):
+  next@16.0.7(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1):
     dependencies:
       '@next/env': 16.0.7
       '@swc/helpers': 0.5.15
@@ -11858,6 +11937,7 @@ snapshots:
       '@next/swc-linux-x64-musl': 16.0.7
       '@next/swc-win32-arm64-msvc': 16.0.7
       '@next/swc-win32-x64-msvc': 16.0.7
+      '@opentelemetry/api': 1.9.0
       sharp: 0.34.5
     transitivePeerDependencies:
       - '@babel/core'
@@ -13590,21 +13670,23 @@ snapshots:
 
   wordwrap@1.0.0: {}
 
-  workflow@4.2.4(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.19(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.17))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.17))(@swc/helpers@0.5.17)(next@16.0.7(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(typescript@5.9.3):
+  workflow@4.2.4(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.19(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.0)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.17))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.17))(@swc/helpers@0.5.17)(next@16.0.7(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(typescript@5.9.3):
     dependencies:
-      '@workflow/astro': 4.0.4(@swc/helpers@0.5.17)
-      '@workflow/cli': 4.2.4(@swc/helpers@0.5.17)
-      '@workflow/core': 4.2.4
+      '@workflow/astro': 4.0.4(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.17)
+      '@workflow/cli': 4.2.4(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.17)
+      '@workflow/core': 4.2.4(@opentelemetry/api@1.9.0)
       '@workflow/errors': 4.1.1
-      '@workflow/nest': 0.0.4(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.19(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.17))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.17))(@swc/helpers@0.5.17)
-      '@workflow/next': 4.0.5(@swc/helpers@0.5.17)(next@16.0.7(react-dom@19.2.1(react@19.2.1))(react@19.2.1))
-      '@workflow/nitro': 4.0.5(@swc/helpers@0.5.17)
-      '@workflow/nuxt': 4.0.5(@swc/helpers@0.5.17)
-      '@workflow/rollup': 4.0.4(@swc/helpers@0.5.17)
-      '@workflow/sveltekit': 4.0.4(@swc/helpers@0.5.17)
+      '@workflow/nest': 0.0.4(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.19(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.0)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.17))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.17))(@swc/helpers@0.5.17)
+      '@workflow/next': 4.0.5(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.17)(next@16.0.7(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))
+      '@workflow/nitro': 4.0.5(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.17)
+      '@workflow/nuxt': 4.0.5(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.17)
+      '@workflow/rollup': 4.0.4(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.17)
+      '@workflow/sveltekit': 4.0.4(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.17)
       '@workflow/typescript-plugin': 4.0.2(typescript@5.9.3)
       '@workflow/utils': 4.1.1
       ms: 2.1.3
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.0
     transitivePeerDependencies:
       - '@nestjs/common'
       - '@nestjs/core'


### PR DESCRIPTION
Closes #9.

## Summary

- Extend `parse_command` to the full PRD grammar (`buy`, `sell N%`, `status`) by keeping the regex pre-filter for the AERO-buy happy path (byte-identical behavior with zero LLM calls) and routing regex misses through a Vercel AI SDK v6 `generateText` + `Output.object` call bound to the new `CommandIntentSchema`.
- `TradeIntentSchema` becomes a Zod discriminated union (`buy`+`usdc_in` positive decimal, `sell`+`percent_out` integer 1..100); `CommandIntentSchema` extends it with `status`.
- Workflow branches on `status` to a no-op handoff step (real behavior is #13) and on `sell` — after `policy_validate` passes — to a templated *"sell execution not yet available"* handoff reply (real behavior is #10). `TODO(#10)` and `TODO(#13)` markers are left for those pickups.
- Grammar rejection copy now matches the PRD § Commodus Voice exemplar verbatim: *"Speak as Rome taught you, gladiator. Valid decrees: ``buy N usdc of SYMBOL``, ``sell N% of SYMBOL``, ``status``."*
- LLM call has retry-once-then-hard-fail semantics; schema failures, gateway errors, and explicit `{ action: "invalid" }` responses all route to the same grammar-rejection outcome via the existing ``publishReplyOnce`` path.

## Key files

- ``lib/execution/intents.ts`` — discriminated-union schemas (``BuyIntentSchema``, ``SellIntentSchema``, ``StatusIntentSchema``, ``TradeIntentSchema``, ``CommandIntentSchema``) + ``isUsdcInIntent`` / ``isTradeIntent`` narrowers.
- ``lib/execution/llm-parse.ts`` — new `parseCommandIntentWithLlm` wrapper with injected-dependency seam for tests; routes via AI Gateway, defaults to ``openai/gpt-5.4-mini``, pins normalization rules in the system prompt, and never invents symbols/sizes not present in user text.
- ``lib/execution/parse.ts`` — two-stage `parseCommandIntent`: regex → LLM fallback; short-circuits on `asset_error` / `oversize_error` without an LLM call.
- ``lib/workflows/commodus-command.ts`` — `parseStep` returns `CommandIntent`; workflow branches top-level on `status`, and after `policy_validate` on `sell`; buys narrow cleanly and flow through the existing #8 pipeline unchanged.
- ``lib/commodus/templates.ts`` — ``REJECTION_REPLIES.grammar`` pinned to the PRD exemplar.
- ``lib/execution/templates.ts`` — new ``HANDOFF_REJECTION_COPY`` for ``sell_not_yet_supported``.
- ``lib/env.ts`` — adds optional ``AI_GATEWAY_API_KEY`` (OIDC-on-Vercel or bearer for self-hosted).

## AC checklist

- [x] `TradeIntentSchema` is a discriminated union on ``action`` covering ``buy`` (usdc_in, positive decimal) and ``sell`` (percent_out, integer 1..100); ``CommandIntentSchema`` extends with ``status``.
- [x] ``parse_command`` runs the regex pre-filter first; on match, behavior is byte-identical to #8 (no LLM call, no added latency). ``lib/commodus/parser.test.ts`` passes unchanged (only a test description was tweaked for accuracy; assertions are identical).
- [x] On regex miss, the step invokes ``generateText`` against ``CommandIntentSchema`` via AI SDK + AI Gateway. One retry on schema or gateway error; second failure records ``error_reason='grammar'`` and publishes the grammar-rejection outcome reply.
- [x] Casual ``sell N% of SYMBOL`` phrasings parse to a ``sell`` ``CommandIntent`` and reach ``policy_validate`` successfully; after validation, a templated *"sell execution not yet available"* reply publishes.
- [x] ``status`` commands parse to ``{ action: "status" }``, skip the entire trade pipeline, and reach a no-op step that marks ``cast_commands`` terminal.
- [x] AERO buy flow from #8 runs unchanged.
- [x] Grammar rejection copy matches the PRD § Commodus Voice exemplar verbatim.
- [x] New ``lib/commodus/command-parser.test.ts`` exercises the LLM fallback with a mocked ``generateText`` (no network): one casual buy, one casual sell, one status, schema-fail → retry → hard-fail, provider-error → retry → hard-fail, explicit-invalid retry-then-grammar, and second-attempt recovery.
- [x] ``pnpm build`` succeeds with both ``OPENAI_API_KEY`` and ``AI_GATEWAY_API_KEY`` unset (LLM is only called on regex miss).
- [x] ``pnpm test`` (66 passed) and ``pnpm typecheck`` pass.

## Out of scope (tracked elsewhere)

- Sell execution (quote, submit, FIFO lots, realized PnL) — **#10**.
- Real ``status`` reply behavior (Snap card / portfolio summary / rank) — **#13** (and **#20** for the Snap-card variant).
- Asset-whitelist widening — the regex still hardcodes AERO; the LLM must not introduce new symbols.
- Removing the \$10 regex cap (noted in #8's closing comment).
- Commodus Voice polish beyond the grammar line — **#16**.
- AI Gateway cost/latency observability — **#18**.
- Multi-command casts.

## Test plan

- [x] ``pnpm test`` — 66/66 pass.
- [x] ``pnpm typecheck`` — clean.
- [x] ``pnpm build`` — clean with AI keys unset.
- [ ] Staging: cast ``@commodus buy 5 usdc of aero`` — observe happy path via #8 with zero LLM calls.
- [ ] Staging: cast ``@commodus sell half my aero`` — observe ``policy_validate`` success + templated sell handoff reply.
- [ ] Staging: cast ``@commodus status`` — observe no-op terminal transition, no outcome cast (per #13 scope).
- [ ] Staging: cast ``@commodus gm`` — observe grammar rejection with the PRD exemplar copy.

Made with [Cursor](https://cursor.com)