### PR TITLE
fix(execution): unbreak LLM fallback + add smoke-parse harness

### DIFF
--- a/lib/commodus/command-parser.test.ts
+++ b/lib/commodus/command-parser.test.ts
@@ -23,9 +23,12 @@ type FakeResult = Awaited<ReturnType<GenerateText>>;
 
 /**
  * Tiny helper that builds a `generateText` stand-in returning a
- * scripted sequence of outputs (object) or errors. Keeps the test
- * surface focused on behavior, not on re-casting the SDK's full
- * result shape.
+ * scripted sequence of intents (or errors). Each non-error value is
+ * wrapped in the `{ intent: ... }` envelope the parser expects — this
+ * matches the OpenAI structured-output contract (schemas must be root
+ * `type: "object"`, so the discriminated union is nested under
+ * `intent`). Keeps the test surface focused on behavior, not on
+ * re-casting the SDK's full result shape.
  */
 function makeFakeLlm(
   sequence: ReadonlyArray<unknown | Error>,
@@ -35,7 +38,7 @@ function makeFakeLlm(
     const value = sequence[calls] ?? sequence[sequence.length - 1];
     calls += 1;
     if (value instanceof Error) throw value;
-    return { output: value } as FakeResult;
+    return { output: { intent: value } } as FakeResult;
   }) as unknown as GenerateText;
   return { generate, callCount: () => calls };
 }

--- a/lib/execution/llm-parse.ts
+++ b/lib/execution/llm-parse.ts
@@ -53,19 +53,37 @@ export const DEFAULT_COMMAND_PARSER_MODEL = "openai/gpt-5.4-mini";
  * Schema sent to the LLM. Includes an `invalid` arm so the model can
  * surface "no command present" without having to throw. The outer
  * helper collapses `invalid` into `{ ok: false, reason: "grammar" }`.
+ *
+ * IMPORTANT: OpenAI's structured-output mode has two constraints that
+ * shape this schema:
+ *   1. The root MUST be `type: "object"` — a bare union serializes to
+ *      a top-level `anyOf` with no `type` and is rejected with
+ *      `"schema must be a JSON Schema of 'type: \"object\"'"`.
+ *   2. `oneOf` is not permitted anywhere — so Zod's
+ *      `z.discriminatedUnion(...)` (which serializes to `oneOf`) is
+ *      rejected with `"'oneOf' is not permitted"` even when nested.
+ *
+ * Workaround: wrap the intent in a single-field object envelope, and
+ * use `z.union(...)` for the intent arms (Zod 4 serializes this to
+ * `anyOf`, which OpenAI accepts). We unwrap `intent` on the way out
+ * and TypeScript still narrows correctly on the `action` literal.
  */
 const InvalidIntentSchema = z.object({
   action: z.literal("invalid"),
 });
 
-const LlmCommandIntentSchema = z.discriminatedUnion("action", [
+const LlmCommandIntentUnion = z.union([
   BuyIntentSchema,
   SellIntentSchema,
   StatusIntentSchema,
   InvalidIntentSchema,
 ]);
 
-export type LlmCommandIntent = z.infer<typeof LlmCommandIntentSchema>;
+const LlmResponseSchema = z.object({
+  intent: LlmCommandIntentUnion,
+});
+
+export type LlmCommandIntent = z.infer<typeof LlmCommandIntentUnion>;
 
 export type LlmParseResult =
   | { ok: true; intent: CommandIntent }
@@ -73,12 +91,19 @@ export type LlmParseResult =
 
 const SYSTEM_PROMPT = `You are the grammar validator for the Commodus Roman-arena trading bot.
 
-Your only job is to classify a single cast text into exactly one of four shapes:
+Your only job is to classify a single cast text and return a JSON object
+of shape { "intent": <one of four intents below> }:
 
   1. buy:    { "action": "buy",    "symbol": "<TICKER>",   "amount_type": "usdc_in",     "amount_value": <positive number> }
   2. sell:   { "action": "sell",   "symbol": "<TICKER>",   "amount_type": "percent_out", "amount_value": <integer 1..100> }
   3. status: { "action": "status" }
   4. invalid:{ "action": "invalid" }
+
+Examples of the full envelope:
+  - { "intent": { "action": "buy",  "symbol": "AERO", "amount_type": "usdc_in",     "amount_value": 5  } }
+  - { "intent": { "action": "sell", "symbol": "AERO", "amount_type": "percent_out", "amount_value": 50 } }
+  - { "intent": { "action": "status" } }
+  - { "intent": { "action": "invalid" } }
 
 Canonical PRD grammar:
   - "buy N usdc of SYMBOL"       e.g. "buy 5 usdc of aero"
@@ -142,7 +167,7 @@ export async function parseCommandIntentWithLlm(
     try {
       const result = await generate({
         model,
-        output: Output.object({ schema: LlmCommandIntentSchema }),
+        output: Output.object({ schema: LlmResponseSchema }),
         system: SYSTEM_PROMPT,
         prompt: `Cast text (already lowercased + mention-stripped): ${JSON.stringify(text)}`,
       });
@@ -150,11 +175,12 @@ export async function parseCommandIntentWithLlm(
       // `result.output` is typed by `Output.object`, but the SDK does
       // not validate against our schema end-to-end — we re-validate so
       // a provider that silently drops fields lands in the retry loop.
-      const parsed = LlmCommandIntentSchema.safeParse(result.output);
+      const parsed = LlmResponseSchema.safeParse(result.output);
       if (!parsed.success) continue;
-      if (parsed.data.action === "invalid") continue;
+      const intent = parsed.data.intent;
+      if (intent.action === "invalid") continue;
 
-      return { ok: true, intent: parsed.data };
+      return { ok: true, intent };
     } catch {
       // Swallow — any gateway or schema error burns one attempt and
       // falls through to the retry or hard-fail below.

--- a/scripts/smoke-parse.ts
+++ b/scripts/smoke-parse.ts
@@ -1,0 +1,205 @@
+/**
+ * Smoke test for `lib/execution/parse.ts` against the live Vercel AI
+ * Gateway.
+ *
+ * Exercises:
+ *   1. Regex pre-filter paths (buy/asset/oversize) that must NOT call
+ *      the gateway. Verifies the cheap path stays cheap.
+ *   2. LLM fallback paths (casual buy/sell/status phrasings +
+ *      unparseable chatter) that route through the gateway.
+ *
+ * Usage:
+ *   AI_GATEWAY_API_KEY=... pnpm tsx scripts/smoke-parse.ts
+ *   pnpm tsx scripts/smoke-parse.ts --model openai/gpt-5.4-nano
+ *   pnpm tsx scripts/smoke-parse.ts --only-llm           # skip regex cases
+ *
+ * Exits non-zero on any unexpected result so it's safe to wire into
+ * a pre-deploy check if we ever want ongoing regression coverage.
+ */
+
+import { generateText } from "ai";
+
+import { parseCommandIntent } from "../lib/execution/parse";
+
+type Expected =
+  | { kind: "ok"; action: "buy" | "sell" | "status" }
+  | { kind: "reject"; reason: "grammar_error" | "asset_error" | "oversize_error" };
+
+type Case = {
+  label: string;
+  text: string;
+  path: "regex" | "llm";
+  expect: Expected;
+};
+
+const CASES: ReadonlyArray<Case> = [
+  // ── Stage 1: regex pre-filter (must not call the gateway) ──────────
+  {
+    label: "canonical AERO buy",
+    text: "@commodus buy 5 usdc of aero",
+    path: "regex",
+    expect: { kind: "ok", action: "buy" },
+  },
+  {
+    label: "AERO buy with decimals",
+    text: "@commodus buy 2.5 usdc of aero",
+    path: "regex",
+    expect: { kind: "ok", action: "buy" },
+  },
+  {
+    label: "structurally valid non-AERO buy (asset_error)",
+    text: "@commodus buy 5 usdc of weth",
+    path: "regex",
+    expect: { kind: "reject", reason: "asset_error" },
+  },
+  {
+    label: "oversize AERO buy (oversize_error)",
+    text: "@commodus buy 100 usdc of aero",
+    path: "regex",
+    expect: { kind: "reject", reason: "oversize_error" },
+  },
+  // ── Stage 2: LLM fallback (live gateway call) ──────────────────────
+  {
+    label: "casual buy — 'grab N usdc worth of'",
+    text: "@commodus grab 2 usdc worth of aero",
+    path: "llm",
+    expect: { kind: "ok", action: "buy" },
+  },
+  {
+    label: "casual sell — 'half my'",
+    text: "@commodus sell half my aero",
+    path: "llm",
+    expect: { kind: "ok", action: "sell" },
+  },
+  {
+    label: "casual sell — 'N% of my'",
+    text: "@commodus sell 25% of my aero",
+    path: "llm",
+    expect: { kind: "ok", action: "sell" },
+  },
+  {
+    label: "casual sell — 'dump all my'",
+    text: "@commodus dump all my aero",
+    path: "llm",
+    expect: { kind: "ok", action: "sell" },
+  },
+  {
+    label: "status — canonical",
+    text: "@commodus status",
+    path: "llm",
+    expect: { kind: "ok", action: "status" },
+  },
+  {
+    label: "status — 'what's my rank?'",
+    text: "@commodus what's my rank?",
+    path: "llm",
+    expect: { kind: "ok", action: "status" },
+  },
+  {
+    label: "non-command chatter (grammar rejection)",
+    text: "@commodus gm",
+    path: "llm",
+    expect: { kind: "reject", reason: "grammar_error" },
+  },
+  {
+    label: "non-command chatter — plain greeting",
+    text: "hello commodus, how are you today",
+    path: "llm",
+    expect: { kind: "reject", reason: "grammar_error" },
+  },
+];
+
+function parseArgs(argv: ReadonlyArray<string>): {
+  model: string | undefined;
+  onlyLlm: boolean;
+} {
+  let model: string | undefined;
+  let onlyLlm = false;
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === "--model") model = argv[++i];
+    else if (arg.startsWith("--model=")) model = arg.slice("--model=".length);
+    else if (arg === "--only-llm") onlyLlm = true;
+  }
+  return { model, onlyLlm };
+}
+
+async function main(): Promise<void> {
+  const { model, onlyLlm } = parseArgs(process.argv.slice(2));
+
+  if (!process.env.AI_GATEWAY_API_KEY && !process.env.VERCEL_OIDC_TOKEN) {
+    console.warn(
+      "⚠  Neither AI_GATEWAY_API_KEY nor VERCEL_OIDC_TOKEN is set. LLM-fallback cases will hard-fail to grammar rejections — that's a config issue, not a regression.",
+    );
+  }
+
+  const cases = onlyLlm ? CASES.filter((c) => c.path === "llm") : CASES;
+
+  // Count gateway calls so we can prove the regex path stays off the
+  // wire. Wrap `generateText` once and inject it into every case.
+  let gatewayCalls = 0;
+  const wrappedGenerate: typeof generateText = (async (
+    args: Parameters<typeof generateText>[0],
+  ) => {
+    gatewayCalls += 1;
+    return generateText(args);
+  }) as typeof generateText;
+
+  let passed = 0;
+  let failed = 0;
+
+  for (const c of cases) {
+    const callsBefore = gatewayCalls;
+    const started = performance.now();
+    const outcome = await parseCommandIntent(c.text, {
+      llm: { generate: wrappedGenerate, ...(model ? { model } : {}) },
+    });
+    const elapsedMs = Math.round(performance.now() - started);
+    const callsAfter = gatewayCalls;
+    const calledGateway = callsAfter > callsBefore;
+
+    const ok = matchesExpectation(outcome, c.expect);
+    const pathOk = calledGateway === (c.path === "llm");
+    const pass = ok && pathOk;
+
+    passed += pass ? 1 : 0;
+    failed += pass ? 0 : 1;
+
+    const status = pass ? "✓" : "✗";
+    const pathTag = calledGateway ? "llm" : "regex";
+    console.log(
+      `${status} [${pathTag.padEnd(5)} ${String(elapsedMs).padStart(4)}ms] ${c.label}`,
+    );
+    console.log(`    in : ${JSON.stringify(c.text)}`);
+    console.log(`    out: ${JSON.stringify(outcome)}`);
+    if (!ok) {
+      console.log(`    expected: ${JSON.stringify(c.expect)}`);
+    }
+    if (!pathOk) {
+      console.log(
+        `    expected path: ${c.path} (gateway calls ${callsBefore} → ${callsAfter})`,
+      );
+    }
+  }
+
+  console.log(
+    `\n${passed} passed, ${failed} failed. Gateway calls total: ${gatewayCalls}.`,
+  );
+
+  if (failed > 0) process.exit(1);
+}
+
+function matchesExpectation(
+  outcome: Awaited<ReturnType<typeof parseCommandIntent>>,
+  expect: Expected,
+): boolean {
+  if (expect.kind === "ok") {
+    return outcome.ok && outcome.intent.action === expect.action;
+  }
+  return !outcome.ok && outcome.reason === expect.reason;
+}
+
+main().catch((err) => {
+  console.error("smoke-parse failed:", err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

- **Critical fix**: The LLM fallback in \`lib/execution/llm-parse.ts\` has been returning HTTP 400 from the AI Gateway on every call since #27 merged. Every casual command (\`sell half my aero\`, \`status\`, \`what's my rank?\`, etc.) was silently collapsing to a grammar rejection. Root cause: OpenAI's strict structured-output mode rejects (1) top-level unions and (2) \`oneOf\` anywhere — both of which Zod 4's \`z.discriminatedUnion\` emits.
- Fix wraps the intent in a \`{ intent }\` envelope and swaps \`z.discriminatedUnion\` → \`z.union\` (which Zod 4 serializes to \`anyOf\`, the permitted form). No behavioral change for the rest of the codebase; TS narrowing on \`.action\` still works.
- Adds \`scripts/smoke-parse.ts\` — the live-gateway regression harness that caught this bug. Exercises regex-only cases (must not touch the gateway — tracked via a wrapped \`generateText\` call counter) and LLM-fallback cases (casual buy/sell, status, chatter).
- Unit tests updated to wrap scripted outputs in the same envelope the real provider now emits.

## Verification

Live run after the fix (\`AI_GATEWAY_API_KEY=… pnpm tsx scripts/smoke-parse.ts\`):

\`\`\`
✓ [regex    0ms] canonical AERO buy
✓ [regex    0ms] AERO buy with decimals
✓ [regex    0ms] structurally valid non-AERO buy (asset_error)
✓ [regex    0ms] oversize AERO buy (oversize_error)
✓ [llm   2505ms] casual buy — 'grab N usdc worth of'
✓ [llm   1332ms] casual sell — 'half my'
✓ [llm   1271ms] casual sell — 'N% of my'
✓ [llm   1172ms] casual sell — 'dump all my'
✓ [llm    972ms] status — canonical
✓ [llm   1423ms] status — 'what's my rank?'
✓ [llm   2789ms] non-command chatter (grammar rejection)
✓ [llm   2069ms] non-command chatter — plain greeting

12 passed, 0 failed. Gateway calls total: 10.
\`\`\`

## Test plan

- [x] \`pnpm test\` (66/66 passing) — unit tests updated for the new envelope shape.
- [x] \`pnpm typecheck\` clean.
- [x] Smoke harness green end-to-end against live gateway.
- [ ] Reviewer: re-run \`AI_GATEWAY_API_KEY=… pnpm tsx scripts/smoke-parse.ts\` after pulling.