### PR TITLE
feat(execution): decode swap logs to populate execution_price_usdc + quantity (#26)

### DIFF
--- a/lib/execution/swap-logs.test.ts
+++ b/lib/execution/swap-logs.test.ts
@@ -1,0 +1,296 @@
+import { describe, expect, it } from "vitest";
+import {
+  encodeEventTopics,
+  erc20Abi,
+  getAddress,
+  pad,
+  toHex,
+  type Address,
+  type Hex,
+  type Log,
+} from "viem";
+
+import { USDC_BASE_ADDRESS } from "@/lib/chain/addresses";
+
+import {
+  SwapLogMissingError,
+  decodeSwapReceipt,
+  type SwapReceiptLike,
+} from "./swap-logs";
+
+const ARENA_WALLET = getAddress(
+  "0x1111111111111111111111111111111111111111",
+);
+const ALLOWANCE_HOLDER = getAddress(
+  "0x0000000000001fF3684f28c67538d4D072C22734",
+);
+const AERO_ADDRESS = getAddress(
+  "0x940181a94A35A4569E4529A3CDfB74e38FD98631",
+);
+const DEGEN_ADDRESS = getAddress(
+  "0x4ed4E862860beD51a9570b96d89aF5E1B0Efefed",
+);
+const POOL_ONE = getAddress("0x2222222222222222222222222222222222222222");
+const POOL_TWO = getAddress("0x3333333333333333333333333333333333333333");
+
+/**
+ * Helper to assemble a `Transfer` event log matching viem's expected
+ * shape. `parseEventLogs` only needs `address`, `topics`, and `data`
+ * to decode — the other fields satisfy the `Log` type.
+ */
+function makeTransferLog(args: {
+  token: Address;
+  from: Address;
+  to: Address;
+  value: bigint;
+  logIndex: number;
+}): Log {
+  const topics = encodeEventTopics({
+    abi: erc20Abi,
+    eventName: "Transfer",
+    args: { from: args.from, to: args.to },
+  }) as [Hex, ...Hex[]];
+  const data = pad(toHex(args.value), { size: 32 });
+  return {
+    address: args.token,
+    topics,
+    data,
+    blockHash: "0x0",
+    blockNumber: BigInt(0),
+    logIndex: args.logIndex,
+    transactionHash: "0x0",
+    transactionIndex: 0,
+    removed: false,
+  } as unknown as Log;
+}
+
+function makeReceipt(logs: Log[]): SwapReceiptLike {
+  return { logs };
+}
+
+describe("decodeSwapReceipt — AERO buy (single hop)", () => {
+  it("extracts net USDC-out + AERO-in with correct price and precision", () => {
+    // 1 USDC in, 0.8214 AERO out → price 1.217458… USDC/AERO
+    const usdcSpent = BigInt(1_000_000); // 6 decimals
+    const aeroReceived = BigInt("821400000000000000"); // 18 decimals
+
+    const receipt = makeReceipt([
+      makeTransferLog({
+        token: USDC_BASE_ADDRESS,
+        from: ARENA_WALLET,
+        to: POOL_ONE,
+        value: usdcSpent,
+        logIndex: 0,
+      }),
+      makeTransferLog({
+        token: AERO_ADDRESS,
+        from: POOL_ONE,
+        to: ARENA_WALLET,
+        value: aeroReceived,
+        logIndex: 1,
+      }),
+    ]);
+
+    const decoded = decodeSwapReceipt(receipt, {
+      walletAddress: ARENA_WALLET,
+      assetAddress: AERO_ADDRESS,
+      assetDecimals: 18,
+    });
+
+    expect(decoded.direction).toBe("usdc_to_asset");
+    expect(decoded.usdcBaseUnits).toBe(usdcSpent);
+    expect(decoded.assetBaseUnits).toBe(aeroReceived);
+    expect(decoded.quantity).toBe("0.8214");
+    // 1 / 0.8214 = 1.217433649866080... USDC/AERO
+    expect(decoded.executionPriceUsdc).toMatch(/^1\.217433/);
+    expect(decoded.quantityNumber).toBeCloseTo(0.8214, 6);
+    expect(decoded.executionPriceUsdcNumber).toBeCloseTo(
+      1 / 0.8214,
+      6,
+    );
+    expect(decoded.usdcHumanNumber).toBeCloseTo(1, 6);
+  });
+});
+
+describe("decodeSwapReceipt — DEGEN buy (multi-hop router)", () => {
+  it("collapses router → pool → wallet hops into the realized fill", () => {
+    // 5 USDC in (via AllowanceHolder → Pool1 → Pool2 → ...), then
+    // DEGEN hops Pool2 → Router → Wallet. The helper should only see
+    // the arena wallet's net flow per token.
+    const usdcSpent = BigInt(5_000_000);
+    const degenReceived = BigInt("450000000000000000000"); // 450 DEGEN (18d)
+
+    const receipt = makeReceipt([
+      makeTransferLog({
+        token: USDC_BASE_ADDRESS,
+        from: ARENA_WALLET,
+        to: ALLOWANCE_HOLDER,
+        value: usdcSpent,
+        logIndex: 0,
+      }),
+      makeTransferLog({
+        token: USDC_BASE_ADDRESS,
+        from: ALLOWANCE_HOLDER,
+        to: POOL_ONE,
+        value: usdcSpent,
+        logIndex: 1,
+      }),
+      makeTransferLog({
+        token: DEGEN_ADDRESS,
+        from: POOL_ONE,
+        to: POOL_TWO,
+        value: degenReceived,
+        logIndex: 2,
+      }),
+      makeTransferLog({
+        token: DEGEN_ADDRESS,
+        from: POOL_TWO,
+        to: ARENA_WALLET,
+        value: degenReceived,
+        logIndex: 3,
+      }),
+    ]);
+
+    const decoded = decodeSwapReceipt(receipt, {
+      walletAddress: ARENA_WALLET,
+      assetAddress: DEGEN_ADDRESS,
+      assetDecimals: 18,
+    });
+
+    expect(decoded.usdcBaseUnits).toBe(usdcSpent);
+    expect(decoded.assetBaseUnits).toBe(degenReceived);
+    expect(decoded.quantity).toBe("450");
+    // 5 / 450 = 0.0111... USDC/DEGEN
+    expect(decoded.executionPriceUsdcNumber).toBeCloseTo(5 / 450, 8);
+  });
+});
+
+describe("decodeSwapReceipt — refund / dust handling", () => {
+  it("nets out a partial USDC refund routed back to the wallet", () => {
+    // Router pulls 1 USDC, refunds 0.01 USDC dust. Net spend = 0.99.
+    const usdcPulled = BigInt(1_000_000);
+    const usdcRefund = BigInt(10_000); // 0.01 USDC
+    const aeroReceived = BigInt("820000000000000000"); // 0.82 AERO
+
+    const receipt = makeReceipt([
+      makeTransferLog({
+        token: USDC_BASE_ADDRESS,
+        from: ARENA_WALLET,
+        to: ALLOWANCE_HOLDER,
+        value: usdcPulled,
+        logIndex: 0,
+      }),
+      makeTransferLog({
+        token: USDC_BASE_ADDRESS,
+        from: ALLOWANCE_HOLDER,
+        to: ARENA_WALLET,
+        value: usdcRefund,
+        logIndex: 1,
+      }),
+      makeTransferLog({
+        token: AERO_ADDRESS,
+        from: POOL_ONE,
+        to: ARENA_WALLET,
+        value: aeroReceived,
+        logIndex: 2,
+      }),
+    ]);
+
+    const decoded = decodeSwapReceipt(receipt, {
+      walletAddress: ARENA_WALLET,
+      assetAddress: AERO_ADDRESS,
+      assetDecimals: 18,
+    });
+
+    expect(decoded.usdcBaseUnits).toBe(usdcPulled - usdcRefund);
+    expect(decoded.assetBaseUnits).toBe(aeroReceived);
+    expect(decoded.usdcHumanNumber).toBeCloseTo(0.99, 6);
+  });
+});
+
+describe("decodeSwapReceipt — missing data", () => {
+  it("throws SwapLogMissingError when no matching transfers exist", () => {
+    const receipt = makeReceipt([]);
+
+    expect(() =>
+      decodeSwapReceipt(receipt, {
+        walletAddress: ARENA_WALLET,
+        assetAddress: AERO_ADDRESS,
+        assetDecimals: 18,
+      }),
+    ).toThrow(SwapLogMissingError);
+  });
+
+  it("throws when USDC-out event is present but asset-in is not", () => {
+    const receipt = makeReceipt([
+      makeTransferLog({
+        token: USDC_BASE_ADDRESS,
+        from: ARENA_WALLET,
+        to: POOL_ONE,
+        value: BigInt(1_000_000),
+        logIndex: 0,
+      }),
+    ]);
+
+    expect(() =>
+      decodeSwapReceipt(receipt, {
+        walletAddress: ARENA_WALLET,
+        assetAddress: AERO_ADDRESS,
+        assetDecimals: 18,
+      }),
+    ).toThrow(SwapLogMissingError);
+  });
+
+  it("ignores transfers on unrelated tokens (e.g. rebase coins)", () => {
+    const UNRELATED = getAddress(
+      "0x9999999999999999999999999999999999999999",
+    );
+
+    const receipt = makeReceipt([
+      makeTransferLog({
+        token: UNRELATED,
+        from: POOL_ONE,
+        to: ARENA_WALLET,
+        value: BigInt(42),
+        logIndex: 0,
+      }),
+      makeTransferLog({
+        token: USDC_BASE_ADDRESS,
+        from: ARENA_WALLET,
+        to: POOL_ONE,
+        value: BigInt(1_000_000),
+        logIndex: 1,
+      }),
+      makeTransferLog({
+        token: AERO_ADDRESS,
+        from: POOL_ONE,
+        to: ARENA_WALLET,
+        value: BigInt("1000000000000000000"),
+        logIndex: 2,
+      }),
+    ]);
+
+    const decoded = decodeSwapReceipt(receipt, {
+      walletAddress: ARENA_WALLET,
+      assetAddress: AERO_ADDRESS,
+      assetDecimals: 18,
+    });
+
+    expect(decoded.quantity).toBe("1");
+  });
+});
+
+describe("decodeSwapReceipt — sell direction (not yet implemented)", () => {
+  it("throws a clear error for asset_to_usdc until #10 lands", () => {
+    const receipt = makeReceipt([]);
+
+    expect(() =>
+      decodeSwapReceipt(receipt, {
+        walletAddress: ARENA_WALLET,
+        assetAddress: AERO_ADDRESS,
+        assetDecimals: 18,
+        direction: "asset_to_usdc",
+      }),
+    ).toThrow(/not implemented/);
+  });
+});

--- a/lib/execution/swap-logs.ts
+++ b/lib/execution/swap-logs.ts
@@ -1,0 +1,212 @@
+import {
+  erc20Abi,
+  formatUnits,
+  getAddress,
+  parseEventLogs,
+  type Address,
+  type Log,
+} from "viem";
+
+import { USDC_BASE_ADDRESS, USDC_DECIMALS } from "@/lib/chain/addresses";
+
+/**
+ * Pure ERC-20 `Transfer`-log decoder for a confirmed 0x Allowance Holder
+ * swap receipt.
+ *
+ * Callers pass the `logs` from an already-fetched `TransactionReceipt`
+ * (no RPC here — keep this module trivially unit-testable against canned
+ * fixtures). The helper sums `Transfer(from, to, value)` events per
+ * token, filtered to the USDC <-> asset pair we care about, and returns
+ * the *net* flows in and out of the arena wallet.
+ *
+ * For MVP we only decode buys (`usdc_to_asset`). Sell decoding is
+ * structurally symmetric — tracked by #10 — and is gated behind the
+ * `direction` parameter so the downstream types can extend without a
+ * rewrite.
+ *
+ * Multi-hop caveat: aggregators typically route through one or two
+ * intermediate pool contracts, so the same token can appear on multiple
+ * `Transfer` logs for a single swap (e.g. `Router -> Pool`, `Pool -> Wallet`).
+ * We only care about the arena wallet's net flow per token, so summing
+ * `to == wallet` minus `from == wallet` collapses any number of hops
+ * into the single realized fill number we need.
+ */
+
+export type SwapDirection = "usdc_to_asset" | "asset_to_usdc";
+
+export interface DecodeSwapReceiptParams {
+  walletAddress: string;
+  assetAddress: string;
+  assetDecimals: number;
+  /** Defaults to `"usdc_to_asset"` (buy). Sell is tracked by #10. */
+  direction?: SwapDirection;
+}
+
+/**
+ * Minimal shape required to decode a swap — the full `TransactionReceipt`
+ * type from viem is wide and tied to chain-specific generics, so we only
+ * depend on the `logs` field. Tests feed hand-rolled fixtures in here.
+ */
+export interface SwapReceiptLike {
+  logs: readonly Log[];
+}
+
+export interface DecodedSwap {
+  direction: SwapDirection;
+  /** Raw USDC base units that left (buy) or arrived at (sell) the wallet. */
+  usdcBaseUnits: bigint;
+  /** Raw asset base units that arrived at (buy) or left (sell) the wallet. */
+  assetBaseUnits: bigint;
+  /**
+   * Full-precision decimal string, safe to write directly into a
+   * `numeric(38, 18)` Postgres column without float coercion.
+   */
+  quantity: string;
+  /** Full-precision decimal string; see {@link DecodedSwap.quantity}. */
+  executionPriceUsdc: string;
+  /** Float convenience field for outcome-reply copy (lossy on extremes). */
+  quantityNumber: number;
+  /** Float convenience field for outcome-reply copy (lossy on extremes). */
+  executionPriceUsdcNumber: number;
+  /** Float convenience field for the realized USDC notional (lossy on extremes). */
+  usdcHumanNumber: number;
+}
+
+/**
+ * Thrown when the receipt has no matching `Transfer` events to derive
+ * the realized fill. Callers should translate to a terminal failure
+ * with `failure_reason='decode_log_missing'` and a failure outcome reply.
+ */
+export class SwapLogMissingError extends Error {
+  readonly reason = "decode_log_missing" as const;
+
+  constructor(message?: string) {
+    super(message ?? "decode_swap_log: no matching Transfer events on receipt");
+    this.name = "SwapLogMissingError";
+  }
+}
+
+/** Price-precision floor for the `numeric(38, 18)` column. */
+const PRICE_FRACTION_DIGITS = 18;
+
+export function decodeSwapReceipt(
+  receipt: SwapReceiptLike,
+  params: DecodeSwapReceiptParams,
+): DecodedSwap {
+  const direction: SwapDirection = params.direction ?? "usdc_to_asset";
+
+  if (direction !== "usdc_to_asset") {
+    // Sell-side decoding is deliberately left for #10. Guarding here
+    // keeps this module's contract explicit instead of silently
+    // returning an inverted (and wrong) result.
+    throw new Error(
+      `decodeSwapReceipt: direction '${direction}' is not implemented (see #10)`,
+    );
+  }
+
+  const wallet = getAddress(params.walletAddress);
+  const usdc = USDC_BASE_ADDRESS;
+  const asset = getAddress(params.assetAddress);
+
+  if (asset === usdc) {
+    // A whitelisted asset identical to USDC is not a meaningful swap
+    // pair and would also collapse the per-token accounting below.
+    throw new Error("decodeSwapReceipt: asset address equals USDC");
+  }
+
+  const transfers = parseEventLogs({
+    abi: erc20Abi,
+    eventName: "Transfer",
+    logs: [...receipt.logs],
+    // Don't throw on foreign or malformed logs — Allowance Holder swaps
+    // frequently emit non-Transfer events we have no business decoding.
+    strict: false,
+  });
+
+  const zero = BigInt(0);
+  let usdcOut = zero;
+  let usdcIn = zero;
+  let assetIn = zero;
+  let assetOut = zero;
+
+  for (const log of transfers) {
+    const token = safeGetAddress(log.address);
+    if (!token) continue;
+
+    const args = log.args as {
+      from?: Address;
+      to?: Address;
+      value?: bigint;
+    };
+    const from = args.from ? safeGetAddress(args.from) : null;
+    const to = args.to ? safeGetAddress(args.to) : null;
+    const value = args.value;
+    if (value === undefined || from === null || to === null) continue;
+
+    if (token === usdc) {
+      if (from === wallet) usdcOut += value;
+      if (to === wallet) usdcIn += value;
+    } else if (token === asset) {
+      if (to === wallet) assetIn += value;
+      if (from === wallet) assetOut += value;
+    }
+  }
+
+  const netUsdcOut = usdcOut - usdcIn;
+  const netAssetIn = assetIn - assetOut;
+
+  if (netUsdcOut <= zero || netAssetIn <= zero) {
+    throw new SwapLogMissingError();
+  }
+
+  const quantity = formatUnits(netAssetIn, params.assetDecimals);
+  const usdcHuman = formatUnits(netUsdcOut, USDC_DECIMALS);
+  const executionPriceUsdc = computePriceUsdc({
+    usdcBaseUnits: netUsdcOut,
+    assetBaseUnits: netAssetIn,
+    assetDecimals: params.assetDecimals,
+  });
+
+  return {
+    direction,
+    usdcBaseUnits: netUsdcOut,
+    assetBaseUnits: netAssetIn,
+    quantity,
+    executionPriceUsdc,
+    quantityNumber: Number(quantity),
+    executionPriceUsdcNumber: Number(executionPriceUsdc),
+    usdcHumanNumber: Number(usdcHuman),
+  };
+}
+
+/**
+ * Computes `usdcHuman / assetHuman` entirely in BigInt space and
+ * formats the result as a 18-decimal string, preserving the full
+ * precision the `numeric(38, 18)` column can hold.
+ *
+ *   priceHuman = usdcBase / 10^6 ÷ assetBase / 10^assetDecimals
+ *              = usdcBase × 10^(assetDecimals − 6) ÷ assetBase
+ *
+ * Scaling up by 10^PRICE_FRACTION_DIGITS inside the numerator gives an
+ * integer with the desired number of fractional digits, which we then
+ * pass to `formatUnits` to get a canonical decimal string.
+ */
+function computePriceUsdc(args: {
+  usdcBaseUnits: bigint;
+  assetBaseUnits: bigint;
+  assetDecimals: number;
+}): string {
+  const scale = BigInt(10) ** BigInt(args.assetDecimals + PRICE_FRACTION_DIGITS);
+  const usdcScale = BigInt(10) ** BigInt(USDC_DECIMALS);
+  const priceScaled =
+    (args.usdcBaseUnits * scale) / (args.assetBaseUnits * usdcScale);
+  return formatUnits(priceScaled, PRICE_FRACTION_DIGITS);
+}
+
+function safeGetAddress(value: string): Address | null {
+  try {
+    return getAddress(value);
+  } catch {
+    return null;
+  }
+}

--- a/lib/workflows/commodus-command.ts
+++ b/lib/workflows/commodus-command.ts
@@ -3,10 +3,7 @@ import { parseUnits, type Hex } from "viem";
 
 import { USDC_BASE_ADDRESS, USDC_DECIMALS } from "@/lib/chain/addresses";
 import { basePublicClient } from "@/lib/chain/client";
-import {
-  REJECTION_REPLIES,
-  buildAcceptedReply,
-} from "@/lib/commodus/templates";
+import { REJECTION_REPLIES } from "@/lib/commodus/templates";
 import { env } from "@/lib/env";
 import { MissingSignerError } from "@/lib/neynar";
 import {
@@ -35,6 +32,10 @@ import {
   reserveOrLoadExecution,
   type ReservedExecution,
 } from "@/lib/execution/reserve";
+import {
+  decodeSwapReceipt,
+  SwapLogMissingError,
+} from "@/lib/execution/swap-logs";
 import {
   buildIntentReply,
   buildOutcomeReply,
@@ -69,10 +70,10 @@ export interface CommandContext {
  * from the furthest-forward populated column (`tx_hash`, `confirmed_at`,
  * `cast_replies` rows, etc.).
  *
- * The happy path is fully implemented; decode / FIFO bookkeeping /
- * scoring are minimal placeholders with TODO markers — the replay-
- * safety and outcome-reply invariants hold regardless of how those
- * are fleshed out.
+ * The happy path is fully implemented through `decode_swap_log` (#26);
+ * FIFO bookkeeping (#10) / score-time price-impact (#12) / full scoring
+ * are minimal placeholders with TODO markers — the replay-safety and
+ * outcome-reply invariants hold regardless of how those are fleshed out.
  */
 export async function handleCommodusCommand(ctx: CommandContext) {
   "use workflow";
@@ -220,6 +221,25 @@ export async function handleCommodusCommand(ctx: CommandContext) {
         txHash: submitted.txHash,
       });
 
+  const decoded = await decodeSwapLog({
+    tradeExecutionId: reservation.tradeExecutionId,
+    txHash: confirmed.txHash,
+    walletAddress: policy.context.walletAddress,
+    assetAddress: policy.context.assetAddress,
+    assetDecimals: policy.context.assetDecimals,
+    reservedNotionalUsdc: netNotional,
+  });
+
+  if (!decoded.ok) {
+    await markTradeExecutionFailed(reservation.tradeExecutionId);
+    await markRejected(ctx.castHash, decoded.reason, "failed");
+    await publishOutcomeReply(
+      ctx.castHash,
+      buildOutcomeReply({ kind: "failure", reason: decoded.reason }),
+    );
+    return { status: "failed" as const, reason: decoded.reason };
+  }
+
   const enforcement = await scoreTimeEnforcement({
     tradeExecutionId: reservation.tradeExecutionId,
     quotedNotional: netNotional,
@@ -247,7 +267,13 @@ export async function handleCommodusCommand(ctx: CommandContext) {
   await markStatus(ctx.castHash, "executed");
   await publishOutcomeReply(
     ctx.castHash,
-    buildAcceptedReply(intent.amount_value),
+    buildOutcomeReply({
+      kind: "success",
+      symbol: intent.symbol,
+      quantity: decoded.quantity,
+      notionalUsdc: decoded.usdcSpent,
+      txHash: confirmed.txHash,
+    }),
   );
 
   return {
@@ -667,6 +693,135 @@ async function verifyTxOnchain(params: {
   }
 
   return { txHash: params.txHash, confirmedAt };
+}
+
+// ---------------------------------------------------------------------------
+// Step: decode_swap_log
+//
+// Pulls the confirmed receipt, decodes the USDC-out + asset-in Transfer
+// events, and persists the realized `quantity` + `execution_price_usdc`
+// onto `trade_executions`. Idempotent: a replay after both columns are
+// populated short-circuits without touching the RPC.
+//
+// Failure modes mirror the issue spec (#26):
+//   - No matching Transfer → terminal failure, `decode_log_missing`.
+//   - Decoded USDC-out drifts from the reserved notional by >10 bps →
+//     terminal failure, `decode_log_mismatch`.
+//   - Receipt not yet indexed → viem throws, the workflow retries.
+// ---------------------------------------------------------------------------
+
+const DECODE_TOLERANCE_BPS = 10;
+type DecodeFailureReason = "decode_log_missing" | "decode_log_mismatch";
+
+type DecodeSwapLogResult =
+  | {
+      ok: true;
+      quantity: number;
+      executionPriceUsdc: number;
+      usdcSpent: number;
+    }
+  | { ok: false; reason: DecodeFailureReason };
+
+async function decodeSwapLog(params: {
+  tradeExecutionId: string;
+  txHash: string;
+  walletAddress: string;
+  assetAddress: string;
+  assetDecimals: number;
+  reservedNotionalUsdc: number;
+}): Promise<DecodeSwapLogResult> {
+  "use step";
+
+  // Idempotency short-circuit. The row is the single source of truth —
+  // a replay never re-fetches the receipt or re-decodes, so this step
+  // is cheap on retries.
+  const { data: existing, error: readErr } = await supabaseAdmin
+    .from("trade_executions")
+    .select("quantity, execution_price_usdc")
+    .eq("id", params.tradeExecutionId)
+    .maybeSingle();
+
+  if (readErr) {
+    throw new Error(`decode_swap_log: read failed: ${readErr.message}`);
+  }
+
+  if (
+    existing?.quantity != null &&
+    existing?.execution_price_usdc != null
+  ) {
+    return {
+      ok: true,
+      quantity: Number(existing.quantity),
+      executionPriceUsdc: Number(existing.execution_price_usdc),
+      usdcSpent: params.reservedNotionalUsdc,
+    };
+  }
+
+  // Receipt must be present by this point — verify_tx_onchain already
+  // waited for one confirmation. `getTransactionReceipt` throws a
+  // retryable `TransactionReceiptNotFoundError` if the RPC hasn't
+  // caught up; that's the desired "non-fatal retry" per the spec.
+  const receipt = await basePublicClient.getTransactionReceipt({
+    hash: params.txHash as Hex,
+  });
+
+  let decoded;
+  try {
+    decoded = decodeSwapReceipt(receipt, {
+      walletAddress: params.walletAddress,
+      assetAddress: params.assetAddress,
+      assetDecimals: params.assetDecimals,
+    });
+  } catch (err) {
+    if (err instanceof SwapLogMissingError) {
+      return { ok: false, reason: "decode_log_missing" };
+    }
+    throw err;
+  }
+
+  // 10 bps sanity check: aggregator routing can round dust in either
+  // direction, but a >0.1% gap between the reserved notional and the
+  // realized USDC-out almost always means we're decoding the wrong tx
+  // or against the wrong asset — fail fast rather than booking bad P&L.
+  const tolerance =
+    (params.reservedNotionalUsdc * DECODE_TOLERANCE_BPS) / 10_000;
+  if (
+    Math.abs(decoded.usdcHumanNumber - params.reservedNotionalUsdc) > tolerance
+  ) {
+    return { ok: false, reason: "decode_log_mismatch" };
+  }
+
+  // Supabase accepts string values on `numeric` columns, so the decimal
+  // strings from `formatUnits` land verbatim — no float round-trip.
+  const { error: updErr } = await supabaseAdmin
+    .from("trade_executions")
+    .update({
+      quantity: decoded.quantity as unknown as number,
+      execution_price_usdc: decoded.executionPriceUsdc as unknown as number,
+    })
+    .eq("id", params.tradeExecutionId);
+
+  if (updErr) {
+    throw new Error(`decode_swap_log: update failed: ${updErr.message}`);
+  }
+
+  return {
+    ok: true,
+    quantity: decoded.quantityNumber,
+    executionPriceUsdc: decoded.executionPriceUsdcNumber,
+    usdcSpent: decoded.usdcHumanNumber,
+  };
+}
+
+async function markTradeExecutionFailed(
+  tradeExecutionId: string,
+): Promise<void> {
+  "use step";
+
+  await supabaseAdmin
+    .from("trade_executions")
+    .update({ status: "failed" })
+    .eq("id", tradeExecutionId);
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #26.

## Summary
- Adds a pure `decodeSwapReceipt` helper (`lib/execution/swap-logs.ts`) that sums ERC-20 `Transfer` events per token and returns the net USDC-out + asset-in flows for the arena wallet, tolerating multi-hop router paths. Returns full-precision decimal strings for the `numeric(38, 18)` columns plus float conveniences for outcome-reply copy; `direction` gates sell-side decoding for forward-compat with #10.
- Inserts a new `decodeSwapLog` workflow step between `verify_tx_onchain` and `score_time_enforcement`. Idempotent (no-op when both columns are populated), retries on missing receipts, and fails terminally with `decode_log_missing` or `decode_log_mismatch` (>10 bps drift vs reserved notional) — marking `trade_executions.status = 'failed'` and publishing the failure outcome reply.
- Swaps the happy-path reply from `buildAcceptedReply` to `buildOutcomeReply({ kind: 'success', ... })` so the decoded quantity + short tx hash actually surface.

## Test plan
- [x] `pnpm test` — 73/73 passing, including 7 new swap-logs cases (AERO single-hop, DEGEN multi-hop, partial refund, missing-transfer failures, unrelated-token ignore, sell-direction guard).
- [x] `pnpm typecheck` — clean.
- [ ] Live smoke: post `@commodus buy 1 usdc of AERO` on staging; confirm `trade_executions.quantity` + `execution_price_usdc` populate and the outcome reply names the decoded AERO amount.
- [ ] Replay: re-trigger a completed cast's workflow and verify the step no-ops (no RPC call, no DB write).
- [ ] Failure paths: manually null `quantity`/`execution_price_usdc` with a bogus `tx_hash` and replay — expect `decode_log_missing` terminal failure + failure reply.

## Out of scope
- Sell-side decoding (tracked by #10; `direction: 'asset_to_usdc'` throws a clear "not implemented" error today).
- Extending `score_time_enforcement` to actually use the decoded fill for a price-impact check (tracked by #12).
- Backfilling historical rows where these columns are NULL.
- Any schema migration — all columns already exist.

Made with [Cursor](https://cursor.com)