### PR TITLE
feat(execution): sell flow, FIFO lots, realized PnL (#10)

### DIFF
--- a/lib/execution/allowance.ts
+++ b/lib/execution/allowance.ts
@@ -43,18 +43,24 @@ export type EnsureAllowanceResult =
   | { kind: "already-approved" }
   | { kind: "approved"; txHash: Hex };
 
-export async function ensureUsdcAllowance(params: {
+/**
+ * Generic ERC-20 MAX approval against the Allowance Holder spender.
+ * `ensureUsdcAllowance` is a thin wrapper for the USDC leg on buys.
+ */
+export async function ensureErc20Allowance(params: {
+  tokenAddress: string;
   walletAddress: string;
   privyWalletId: string;
   spender: string;
   minRequired: bigint;
   referenceId: string;
 }): Promise<EnsureAllowanceResult> {
+  const token = getAddress(params.tokenAddress);
   const owner = getAddress(params.walletAddress);
   const spender = getAddress(params.spender);
 
   const current = await basePublicClient.readContract({
-    address: USDC_BASE_ADDRESS,
+    address: token,
     abi: erc20Abi,
     functionName: "allowance",
     args: [owner, spender],
@@ -72,7 +78,7 @@ export async function ensureUsdcAllowance(params: {
 
   const submitted = await signAndSendTransaction({
     walletId: params.privyWalletId,
-    to: USDC_BASE_ADDRESS,
+    to: token,
     data,
     sponsor: env.PRIVY_SPONSOR_GAS,
     referenceId: `${params.referenceId}:approve`,
@@ -108,4 +114,21 @@ export async function ensureUsdcAllowance(params: {
   });
 
   return { kind: "approved", txHash: hash as Hex };
+}
+
+export async function ensureUsdcAllowance(params: {
+  walletAddress: string;
+  privyWalletId: string;
+  spender: string;
+  minRequired: bigint;
+  referenceId: string;
+}): Promise<EnsureAllowanceResult> {
+  return ensureErc20Allowance({
+    tokenAddress: USDC_BASE_ADDRESS,
+    walletAddress: params.walletAddress,
+    privyWalletId: params.privyWalletId,
+    spender: params.spender,
+    minRequired: params.minRequired,
+    referenceId: params.referenceId,
+  });
 }

--- a/lib/execution/lot-accounting.test.ts
+++ b/lib/execution/lot-accounting.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+
+import { fifoRealizedSell } from "./lot-accounting";
+
+describe("fifoRealizedSell", () => {
+  it("single-lot full close", () => {
+    const r = fifoRealizedSell({
+      openLotsOldestFirst: [
+        { id: "lot-a", remainingQuantity: 10, avgCostUsdc: 1 },
+      ],
+      sellQuantity: 10,
+      netProceedsUsdc: 15,
+    });
+
+    expect(r.closures).toHaveLength(1);
+    expect(r.closures[0]!.lotId).toBe("lot-a");
+    expect(r.closures[0]!.quantityClosed).toBe(10);
+    expect(r.closures[0]!.realizedPnlUsdc).toBeCloseTo(5, 8);
+    expect(r.closures[0]!.realizedReturnPct).toBeCloseTo(50, 6);
+    expect(r.totalRealizedPnlUsdc).toBeCloseTo(5, 8);
+    expect(r.aggregateReturnPct).toBeCloseTo(50, 6);
+    expect(r.lotRemainings[0]!.remainingQuantity).toBeCloseTo(0, 8);
+    expect(r.lotRemainings[0]!.closedAtIso).not.toBeNull();
+  });
+
+  it("single-lot partial close", () => {
+    const r = fifoRealizedSell({
+      openLotsOldestFirst: [
+        { id: "lot-a", remainingQuantity: 10, avgCostUsdc: 2 },
+      ],
+      sellQuantity: 4,
+      netProceedsUsdc: 12,
+    });
+
+    expect(r.closures).toHaveLength(1);
+    expect(r.closures[0]!.quantityClosed).toBe(4);
+    // exit 3 USDC/unit, cost 2 → pnl 1 per unit × 4 = 4
+    expect(r.closures[0]!.realizedPnlUsdc).toBeCloseTo(4, 8);
+    expect(r.lotRemainings[0]!.remainingQuantity).toBeCloseTo(6, 8);
+    expect(r.lotRemainings[0]!.closedAtIso).toBeNull();
+  });
+
+  it("multi-lot partial close", () => {
+    const r = fifoRealizedSell({
+      openLotsOldestFirst: [
+        { id: "lot-a", remainingQuantity: 10, avgCostUsdc: 1 },
+        { id: "lot-b", remainingQuantity: 10, avgCostUsdc: 2 },
+      ],
+      sellQuantity: 15,
+      netProceedsUsdc: 22.5,
+    });
+
+    expect(r.closures).toHaveLength(2);
+    expect(r.closures[0]!.lotId).toBe("lot-a");
+    expect(r.closures[0]!.quantityClosed).toBe(10);
+    expect(r.closures[1]!.lotId).toBe("lot-b");
+    expect(r.closures[1]!.quantityClosed).toBe(5);
+
+    // exit 1.5/unit; lot-a pnl 10*(1.5-1)=5, lot-b pnl 5*(1.5-2)=-2.5
+    expect(r.totalRealizedPnlUsdc).toBeCloseTo(2.5, 8);
+    expect(r.totalCostBasisUsdc).toBeCloseTo(20, 8);
+    expect(r.aggregateReturnPct).toBeCloseTo(12.5, 6);
+  });
+});

--- a/lib/execution/lot-accounting.ts
+++ b/lib/execution/lot-accounting.ts
@@ -1,0 +1,113 @@
+/**
+ * FIFO lot consumption for sell executions — pure helpers so Vitest can
+ * pin single-lot / multi-lot scenarios without a database.
+ */
+
+export type OpenLotForFifo = {
+  id: string;
+  remainingQuantity: number;
+  avgCostUsdc: number;
+};
+
+export type FifoLotClosureDraft = {
+  lotId: string;
+  quantityClosed: number;
+  avgCostUsdcAtClose: number;
+  realizedPnlUsdc: number;
+  realizedReturnPct: number;
+};
+
+export type FifoLotRemainingDraft = {
+  lotId: string;
+  remainingQuantity: number;
+  /** ISO timestamp when the lot is fully closed; null if still open. */
+  closedAtIso: string | null;
+};
+
+export type FifoSellResult = {
+  closures: FifoLotClosureDraft[];
+  lotRemainings: FifoLotRemainingDraft[];
+  totalCostBasisUsdc: number;
+  totalRealizedPnlUsdc: number;
+  /** Aggregate return vs cost of closed pieces; null if no cost. */
+  aggregateReturnPct: number | null;
+};
+
+const QTY_EPS = 1e-12;
+
+/**
+ * Consumes open lots oldest-first until `sellQuantity` units are matched.
+ * Proceeds are allocated at a uniform exit price `netProceedsUsdc / sellQuantity`
+ * so per-lot PnL partitions sum to the portfolio-level PnL.
+ */
+export function fifoRealizedSell(args: {
+  openLotsOldestFirst: OpenLotForFifo[];
+  sellQuantity: number;
+  netProceedsUsdc: number;
+}): FifoSellResult {
+  const { openLotsOldestFirst, sellQuantity, netProceedsUsdc } = args;
+
+  if (!(sellQuantity > QTY_EPS)) {
+    throw new Error("fifoRealizedSell: sellQuantity must be positive");
+  }
+  if (!Number.isFinite(netProceedsUsdc)) {
+    throw new Error("fifoRealizedSell: netProceedsUsdc must be finite");
+  }
+
+  const exitPriceUsdcPerUnit = netProceedsUsdc / sellQuantity;
+  let remainingToSell = sellQuantity;
+  const closures: FifoLotClosureDraft[] = [];
+  const lotRemainings: FifoLotRemainingDraft[] = [];
+  let totalCostBasisUsdc = 0;
+  let totalRealizedPnlUsdc = 0;
+  const nowIso = new Date().toISOString();
+
+  for (const lot of openLotsOldestFirst) {
+    if (remainingToSell <= QTY_EPS) break;
+    if (!(lot.remainingQuantity > QTY_EPS)) continue;
+
+    const take = Math.min(lot.remainingQuantity, remainingToSell);
+    const costPortion = take * lot.avgCostUsdc;
+    const proceedsPortion = take * exitPriceUsdcPerUnit;
+    const realizedPnlUsdc = proceedsPortion - costPortion;
+    const realizedReturnPct =
+      costPortion > QTY_EPS ? (realizedPnlUsdc / costPortion) * 100 : 0;
+
+    closures.push({
+      lotId: lot.id,
+      quantityClosed: take,
+      avgCostUsdcAtClose: lot.avgCostUsdc,
+      realizedPnlUsdc,
+      realizedReturnPct,
+    });
+
+    totalCostBasisUsdc += costPortion;
+    totalRealizedPnlUsdc += realizedPnlUsdc;
+
+    const newRemaining = lot.remainingQuantity - take;
+    lotRemainings.push({
+      lotId: lot.id,
+      remainingQuantity: newRemaining,
+      closedAtIso: newRemaining <= QTY_EPS ? nowIso : null,
+    });
+
+    remainingToSell -= take;
+  }
+
+  if (remainingToSell > QTY_EPS) {
+    throw new Error("fifoRealizedSell: insufficient open lot quantity");
+  }
+
+  const aggregateReturnPct =
+    totalCostBasisUsdc > QTY_EPS
+      ? (totalRealizedPnlUsdc / totalCostBasisUsdc) * 100
+      : null;
+
+  return {
+    closures,
+    lotRemainings,
+    totalCostBasisUsdc,
+    totalRealizedPnlUsdc,
+    aggregateReturnPct,
+  };
+}

--- a/lib/execution/lot-persistence.ts
+++ b/lib/execution/lot-persistence.ts
@@ -1,0 +1,295 @@
+import "server-only";
+
+import { supabaseAdmin } from "@/lib/supabase/server";
+
+import { fifoRealizedSell } from "@/lib/execution/lot-accounting";
+import { isUniqueViolation } from "@/lib/execution/reserve";
+
+type ExecutionIntentRow = {
+  id: string;
+  quantity: number | null;
+  execution_price_usdc: number | null;
+  notional_usdc: number | null;
+  swap_fee_usdc: number | null;
+  sponsored_gas_usdc: number | null;
+  trade_intents: {
+    action: string;
+    asset_symbol: string;
+    wallet_id: string;
+  };
+};
+
+/**
+ * Idempotent FIFO bookkeeping after `decode_swap_log` populated the
+ * execution row. Buys insert an `lots` row + upsert `positions`. Sells
+ * consume lots FIFO, insert `lot_closures`, refresh `positions`, and
+ * stamp `realized_pnl_usdc` / `realized_return_pct` on the execution.
+ */
+export async function applyLotsAndPositionsForExecution(
+  tradeExecutionId: string,
+): Promise<void> {
+  const { data: row, error: readErr } = await supabaseAdmin
+    .from("trade_executions")
+    .select(
+      `
+      id,
+      quantity,
+      execution_price_usdc,
+      notional_usdc,
+      swap_fee_usdc,
+      sponsored_gas_usdc,
+      trade_intents ( action, asset_symbol, wallet_id )
+    `,
+    )
+    .eq("id", tradeExecutionId)
+    .maybeSingle();
+
+  if (readErr) {
+    throw new Error(`apply_lots: read trade_executions failed: ${readErr.message}`);
+  }
+  if (!row) throw new Error("apply_lots: trade_executions row missing");
+
+  const joined = row as unknown as ExecutionIntentRow;
+  const intent = joined.trade_intents;
+  if (!intent) throw new Error("apply_lots: trade_intents join missing");
+
+  const qty = joined.quantity;
+  if (qty == null) throw new Error("apply_lots: quantity not set on execution");
+
+  if (intent.action === "buy") {
+    await applyBuyLot({
+      tradeExecutionId,
+      walletId: intent.wallet_id,
+      symbol: intent.asset_symbol,
+      quantity: Number(qty),
+      swapFeeUsdc: Number(joined.swap_fee_usdc ?? 0),
+      sponsoredGasUsdc: Number(joined.sponsored_gas_usdc ?? 0),
+      usdcSpentOnSwap: Number(joined.notional_usdc ?? 0),
+    });
+    return;
+  }
+
+  if (intent.action === "sell") {
+    await applySellFifo({
+      tradeExecutionId,
+      walletId: intent.wallet_id,
+      symbol: intent.asset_symbol,
+      sellQuantity: Number(qty),
+      grossUsdcIn: Number(joined.notional_usdc ?? 0),
+      swapFeeUsdc: Number(joined.swap_fee_usdc ?? 0),
+    });
+    return;
+  }
+
+  throw new Error(`apply_lots: unsupported intent action ${intent.action}`);
+}
+
+async function applyBuyLot(params: {
+  tradeExecutionId: string;
+  walletId: string;
+  symbol: string;
+  quantity: number;
+  swapFeeUsdc: number;
+  sponsoredGasUsdc: number;
+  usdcSpentOnSwap: number;
+}): Promise<void> {
+  const { data: existing } = await supabaseAdmin
+    .from("lots")
+    .select("id")
+    .eq("opening_execution_id", params.tradeExecutionId)
+    .maybeSingle();
+
+  if (existing) return;
+
+  const totalCostUsdc =
+    params.usdcSpentOnSwap + params.swapFeeUsdc + params.sponsoredGasUsdc;
+  const avgCostUsdc =
+    params.quantity > 0 ? totalCostUsdc / params.quantity : 0;
+
+  const { error: lotErr } = await supabaseAdmin.from("lots").insert({
+    wallet_id: params.walletId,
+    asset_symbol: params.symbol,
+    initial_quantity: params.quantity,
+    remaining_quantity: params.quantity,
+    avg_cost_usdc: avgCostUsdc,
+    opening_execution_id: params.tradeExecutionId,
+  });
+
+  if (lotErr) {
+    if (isUniqueViolation(lotErr)) return;
+    throw new Error(`apply_lots: lots insert failed: ${lotErr.message}`);
+  }
+
+  const { data: pos, error: posReadErr } = await supabaseAdmin
+    .from("positions")
+    .select("quantity, avg_cost_usdc")
+    .eq("wallet_id", params.walletId)
+    .eq("asset_symbol", params.symbol)
+    .maybeSingle();
+
+  if (posReadErr) {
+    throw new Error(`apply_lots: positions read failed: ${posReadErr.message}`);
+  }
+
+  const oldQty = pos ? Number(pos.quantity) : 0;
+  const oldAvg = pos ? Number(pos.avg_cost_usdc) : 0;
+  const newQty = oldQty + params.quantity;
+  const newAvg =
+    newQty > 0
+      ? oldQty > 0
+        ? (oldQty * oldAvg + params.quantity * avgCostUsdc) / newQty
+        : avgCostUsdc
+      : 0;
+
+  const { error: posUpdErr } = await supabaseAdmin.from("positions").upsert(
+    {
+      wallet_id: params.walletId,
+      asset_symbol: params.symbol,
+      quantity: newQty,
+      avg_cost_usdc: newAvg,
+    },
+    { onConflict: "wallet_id,asset_symbol" },
+  );
+
+  if (posUpdErr) {
+    throw new Error(`apply_lots: positions upsert failed: ${posUpdErr.message}`);
+  }
+}
+
+async function applySellFifo(params: {
+  tradeExecutionId: string;
+  walletId: string;
+  symbol: string;
+  sellQuantity: number;
+  grossUsdcIn: number;
+  swapFeeUsdc: number;
+}): Promise<void> {
+  const { data: existingClosure } = await supabaseAdmin
+    .from("lot_closures")
+    .select("id")
+    .eq("closing_execution_id", params.tradeExecutionId)
+    .limit(1)
+    .maybeSingle();
+
+  if (existingClosure) return;
+
+  const netProceedsUsdc = params.grossUsdcIn - params.swapFeeUsdc;
+
+  const { data: openLots, error: lotsErr } = await supabaseAdmin
+    .from("lots")
+    .select("id, remaining_quantity, avg_cost_usdc, opened_at")
+    .eq("wallet_id", params.walletId)
+    .eq("asset_symbol", params.symbol)
+    .gt("remaining_quantity", 0)
+    .order("opened_at", { ascending: true });
+
+  if (lotsErr) {
+    throw new Error(`apply_lots: lots fifo query failed: ${lotsErr.message}`);
+  }
+
+  const fifoInput = (openLots ?? []).map((l) => ({
+    id: l.id,
+    remainingQuantity: Number(l.remaining_quantity),
+    avgCostUsdc: Number(l.avg_cost_usdc),
+  }));
+
+  const fifo = fifoRealizedSell({
+    openLotsOldestFirst: fifoInput,
+    sellQuantity: params.sellQuantity,
+    netProceedsUsdc,
+  });
+
+  for (const c of fifo.closures) {
+    const { error: insErr } = await supabaseAdmin.from("lot_closures").insert({
+      lot_id: c.lotId,
+      closing_execution_id: params.tradeExecutionId,
+      quantity_closed: c.quantityClosed,
+      avg_cost_usdc_at_close: c.avgCostUsdcAtClose,
+      realized_pnl_usdc: c.realizedPnlUsdc,
+      realized_return_pct: c.realizedReturnPct,
+    });
+    if (insErr && !isUniqueViolation(insErr)) {
+      throw new Error(`apply_lots: lot_closures insert failed: ${insErr.message}`);
+    }
+  }
+
+  for (const u of fifo.lotRemainings) {
+    const { error: updErr } = await supabaseAdmin
+      .from("lots")
+      .update({
+        remaining_quantity: u.remainingQuantity,
+        closed_at: u.closedAtIso,
+      })
+      .eq("id", u.lotId);
+    if (updErr) {
+      throw new Error(`apply_lots: lots update failed: ${updErr.message}`);
+    }
+  }
+
+  const { error: execErr } = await supabaseAdmin
+    .from("trade_executions")
+    .update({
+      realized_pnl_usdc: fifo.totalRealizedPnlUsdc,
+      realized_return_pct: fifo.aggregateReturnPct ?? null,
+    })
+    .eq("id", params.tradeExecutionId);
+
+  if (execErr) {
+    throw new Error(`apply_lots: trade_executions pnl update failed: ${execErr.message}`);
+  }
+
+  await refreshPositionFromOpenLots(params.walletId, params.symbol);
+}
+
+async function refreshPositionFromOpenLots(
+  walletId: string,
+  symbol: string,
+): Promise<void> {
+  const { data: lots, error } = await supabaseAdmin
+    .from("lots")
+    .select("remaining_quantity, avg_cost_usdc")
+    .eq("wallet_id", walletId)
+    .eq("asset_symbol", symbol)
+    .gt("remaining_quantity", 0);
+
+  if (error) {
+    throw new Error(`apply_lots: lots summary query failed: ${error.message}`);
+  }
+
+  if (!lots?.length) {
+    const { error: delErr } = await supabaseAdmin
+      .from("positions")
+      .delete()
+      .eq("wallet_id", walletId)
+      .eq("asset_symbol", symbol);
+    if (delErr) {
+      throw new Error(`apply_lots: positions delete failed: ${delErr.message}`);
+    }
+    return;
+  }
+
+  let qtySum = 0;
+  let costSum = 0;
+  for (const l of lots) {
+    const rem = Number(l.remaining_quantity);
+    const avg = Number(l.avg_cost_usdc);
+    qtySum += rem;
+    costSum += rem * avg;
+  }
+
+  const avgCost = qtySum > 0 ? costSum / qtySum : 0;
+
+  const { error: upErr } = await supabaseAdmin.from("positions").upsert(
+    {
+      wallet_id: walletId,
+      asset_symbol: symbol,
+      quantity: qtySum,
+      avg_cost_usdc: avgCost,
+    },
+    { onConflict: "wallet_id,asset_symbol" },
+  );
+
+  if (upErr) {
+    throw new Error(`apply_lots: positions refresh upsert failed: ${upErr.message}`);
+  }
+}

--- a/lib/execution/policy.ts
+++ b/lib/execution/policy.ts
@@ -1,6 +1,6 @@
 import "server-only";
 
-import { type Address, getAddress } from "viem";
+import { parseUnits, type Address, getAddress } from "viem";
 
 import { readUsdcBalance } from "@/lib/chain/erc20";
 import { supabaseAdmin } from "@/lib/supabase/server";
@@ -20,6 +20,8 @@ import type { TradeIntent } from "./intents";
  *   3. max_trades_per_day   — slot count for the UTC day
  *   4. max_trade_usdc       — size cap (buys only)
  *   5. wallet_cap_usdc      — live arena-wallet USDC via viem (buys only)
+ *   6. insufficient_position — sells: DB position missing, zero-size, or
+ *                              computed sell amount rounds to zero on-chain
  *
  * Per-intent-type rules apply only where stated: sell intents skip
  * size and wallet-cap checks (sells pay out USDC; they don't consume it).
@@ -33,7 +35,8 @@ export type PolicyRejectionReason =
   | "asset_not_whitelisted"
   | "max_trades_per_day"
   | "max_trade_usdc"
-  | "wallet_cap_usdc";
+  | "wallet_cap_usdc"
+  | "insufficient_position";
 
 export type PolicyResult =
   | { ok: true; context: PolicyContext }
@@ -50,6 +53,11 @@ export type PolicyContext = {
   privyWalletId: string;
   assetAddress: Address;
   assetDecimals: number;
+  /**
+   * Sells only — exact asset base units computed from `positions.quantity`
+   * × percent (integer 1–100), floored, used as the 0x `sellAmount`.
+   */
+  sellAssetBaseUnits?: string;
   policy: {
     maxTradeUsdc: number;
     maxTradesPerDay: number;
@@ -102,6 +110,39 @@ export async function validatePolicy(
     }
   }
 
+  let sellAssetBaseUnits: string | undefined;
+  if (!isBuy) {
+    const position = await loadPositionQuantity(
+      params.walletId,
+      params.intent.symbol,
+    );
+    if (!position) {
+      return { ok: false, reason: "insufficient_position" };
+    }
+
+    let positionWei: bigint;
+    try {
+      positionWei = parseUnits(
+        String(position.quantity).trim(),
+        asset.decimals,
+      );
+    } catch {
+      return { ok: false, reason: "insufficient_position" };
+    }
+
+    if (positionWei <= BigInt(0)) {
+      return { ok: false, reason: "insufficient_position" };
+    }
+
+    const sellWei =
+      (positionWei * BigInt(params.intent.amount_value)) / BigInt(100);
+    if (sellWei <= BigInt(0)) {
+      return { ok: false, reason: "insufficient_position" };
+    }
+
+    sellAssetBaseUnits = sellWei.toString();
+  }
+
   return {
     ok: true,
     context: {
@@ -110,6 +151,7 @@ export async function validatePolicy(
       privyWalletId: params.privyWalletId,
       assetAddress: getAddress(asset.address),
       assetDecimals: asset.decimals,
+      sellAssetBaseUnits,
       policy,
     },
   };
@@ -182,6 +224,28 @@ async function countTradesToday(walletId: string): Promise<number> {
 }
 
 type PolicyRow = PolicyContext["policy"];
+
+async function loadPositionQuantity(
+  walletId: string,
+  assetSymbol: string,
+): Promise<{ quantity: string } | null> {
+  const { data, error } = await supabaseAdmin
+    .from("positions")
+    .select("quantity")
+    .eq("wallet_id", walletId)
+    .eq("asset_symbol", assetSymbol)
+    .maybeSingle();
+
+  if (error) {
+    throw new Error(`positions lookup failed: ${error.message}`);
+  }
+  if (!data) return null;
+
+  const qty = String(data.quantity).trim();
+  if (!qty || Number(qty) <= 0) return null;
+
+  return { quantity: qty };
+}
 
 async function loadPolicy(walletId: string): Promise<PolicyRow> {
   const { data, error } = await supabaseAdmin

--- a/lib/execution/swap-logs.test.ts
+++ b/lib/execution/swap-logs.test.ts
@@ -280,17 +280,39 @@ describe("decodeSwapReceipt — missing data", () => {
   });
 });
 
-describe("decodeSwapReceipt — sell direction (not yet implemented)", () => {
-  it("throws a clear error for asset_to_usdc until #10 lands", () => {
-    const receipt = makeReceipt([]);
+describe("decodeSwapReceipt — sell (asset_to_usdc)", () => {
+  it("extracts net asset-out + USDC-in with correct price", () => {
+    const aeroSold = BigInt("821400000000000000"); // 0.8214 AERO
+    const usdcReceived = BigInt(1_000_000); // 1 USDC
 
-    expect(() =>
-      decodeSwapReceipt(receipt, {
-        walletAddress: ARENA_WALLET,
-        assetAddress: AERO_ADDRESS,
-        assetDecimals: 18,
-        direction: "asset_to_usdc",
+    const receipt = makeReceipt([
+      makeTransferLog({
+        token: AERO_ADDRESS,
+        from: ARENA_WALLET,
+        to: POOL_ONE,
+        value: aeroSold,
+        logIndex: 0,
       }),
-    ).toThrow(/not implemented/);
+      makeTransferLog({
+        token: USDC_BASE_ADDRESS,
+        from: POOL_ONE,
+        to: ARENA_WALLET,
+        value: usdcReceived,
+        logIndex: 1,
+      }),
+    ]);
+
+    const decoded = decodeSwapReceipt(receipt, {
+      walletAddress: ARENA_WALLET,
+      assetAddress: AERO_ADDRESS,
+      assetDecimals: 18,
+      direction: "asset_to_usdc",
+    });
+
+    expect(decoded.direction).toBe("asset_to_usdc");
+    expect(decoded.usdcBaseUnits).toBe(usdcReceived);
+    expect(decoded.assetBaseUnits).toBe(aeroSold);
+    expect(decoded.quantity).toBe("0.8214");
+    expect(decoded.usdcHumanNumber).toBeCloseTo(1, 6);
   });
 });

--- a/lib/execution/swap-logs.ts
+++ b/lib/execution/swap-logs.ts
@@ -19,10 +19,9 @@ import { USDC_BASE_ADDRESS, USDC_DECIMALS } from "@/lib/chain/addresses";
  * token, filtered to the USDC <-> asset pair we care about, and returns
  * the *net* flows in and out of the arena wallet.
  *
- * For MVP we only decode buys (`usdc_to_asset`). Sell decoding is
- * structurally symmetric — tracked by #10 — and is gated behind the
- * `direction` parameter so the downstream types can extend without a
- * rewrite.
+ * Both buy (`usdc_to_asset`) and sell (`asset_to_usdc`) directions are
+ * supported; callers pass `direction` explicitly so the netting math is
+ * never ambiguous.
  *
  * Multi-hop caveat: aggregators typically route through one or two
  * intermediate pool contracts, so the same token can appear on multiple
@@ -95,15 +94,6 @@ export function decodeSwapReceipt(
 ): DecodedSwap {
   const direction: SwapDirection = params.direction ?? "usdc_to_asset";
 
-  if (direction !== "usdc_to_asset") {
-    // Sell-side decoding is deliberately left for #10. Guarding here
-    // keeps this module's contract explicit instead of silently
-    // returning an inverted (and wrong) result.
-    throw new Error(
-      `decodeSwapReceipt: direction '${direction}' is not implemented (see #10)`,
-    );
-  }
-
   const wallet = getAddress(params.walletAddress);
   const usdc = USDC_BASE_ADDRESS;
   const asset = getAddress(params.assetAddress);
@@ -153,24 +143,52 @@ export function decodeSwapReceipt(
   }
 
   const netUsdcOut = usdcOut - usdcIn;
+  const netUsdcIn = usdcIn - usdcOut;
   const netAssetIn = assetIn - assetOut;
+  const netAssetOut = assetOut - assetIn;
 
-  if (netUsdcOut <= zero || netAssetIn <= zero) {
+  if (direction === "usdc_to_asset") {
+    if (netUsdcOut <= zero || netAssetIn <= zero) {
+      throw new SwapLogMissingError();
+    }
+
+    const quantity = formatUnits(netAssetIn, params.assetDecimals);
+    const usdcHuman = formatUnits(netUsdcOut, USDC_DECIMALS);
+    const executionPriceUsdc = computePriceUsdc({
+      usdcBaseUnits: netUsdcOut,
+      assetBaseUnits: netAssetIn,
+      assetDecimals: params.assetDecimals,
+    });
+
+    return {
+      direction,
+      usdcBaseUnits: netUsdcOut,
+      assetBaseUnits: netAssetIn,
+      quantity,
+      executionPriceUsdc,
+      quantityNumber: Number(quantity),
+      executionPriceUsdcNumber: Number(executionPriceUsdc),
+      usdcHumanNumber: Number(usdcHuman),
+    };
+  }
+
+  // asset_to_usdc — arena sends asset, receives USDC (symmetric netting).
+  if (netAssetOut <= zero || netUsdcIn <= zero) {
     throw new SwapLogMissingError();
   }
 
-  const quantity = formatUnits(netAssetIn, params.assetDecimals);
-  const usdcHuman = formatUnits(netUsdcOut, USDC_DECIMALS);
+  const quantity = formatUnits(netAssetOut, params.assetDecimals);
+  const usdcHuman = formatUnits(netUsdcIn, USDC_DECIMALS);
   const executionPriceUsdc = computePriceUsdc({
-    usdcBaseUnits: netUsdcOut,
-    assetBaseUnits: netAssetIn,
+    usdcBaseUnits: netUsdcIn,
+    assetBaseUnits: netAssetOut,
     assetDecimals: params.assetDecimals,
   });
 
   return {
     direction,
-    usdcBaseUnits: netUsdcOut,
-    assetBaseUnits: netAssetIn,
+    usdcBaseUnits: netUsdcIn,
+    assetBaseUnits: netAssetOut,
     quantity,
     executionPriceUsdc,
     quantityNumber: Number(quantity),

--- a/lib/execution/templates.test.ts
+++ b/lib/execution/templates.test.ts
@@ -24,9 +24,11 @@ describe("buildIntentReply", () => {
       action: "sell",
       symbol: "AERO",
       amount_type: "percent_out",
-      amount_value: 100,
+      amount_value: 50,
     });
     expect(text).toContain("retire");
+    expect(text).toContain("50%");
+    expect(text).toContain("AERO");
   });
 });
 
@@ -34,6 +36,7 @@ describe("buildOutcomeReply", () => {
   it("includes quantity + notional + short tx hash on success", () => {
     const text = buildOutcomeReply({
       kind: "success",
+      action: "buy",
       symbol: "AERO",
       quantity: 12.34567,
       notionalUsdc: 4.95,
@@ -61,5 +64,22 @@ describe("POLICY_REJECTION_COPY", () => {
     expect(POLICY_REJECTION_COPY.max_trades_per_day).toBeTruthy();
     expect(POLICY_REJECTION_COPY.max_trade_usdc).toBeTruthy();
     expect(POLICY_REJECTION_COPY.wallet_cap_usdc).toBeTruthy();
+    expect(POLICY_REJECTION_COPY.insufficient_position).toBeTruthy();
+  });
+
+  it("includes realized PnL on sell success outcomes", () => {
+    const text = buildOutcomeReply({
+      kind: "success",
+      action: "sell",
+      symbol: "AERO",
+      quantity: 2,
+      notionalUsdc: 10,
+      txHash: "0x0123456789abcdef0123456789abcdef",
+      realizedPnlUsdc: 1.25,
+    });
+    expect(text).toContain("Retired");
+    expect(text).toContain("Realized PnL");
+    expect(text).toContain("1.25");
+    expect(text).toContain("USDC");
   });
 });

--- a/lib/execution/templates.ts
+++ b/lib/execution/templates.ts
@@ -9,17 +9,27 @@ import type { TradeIntent } from "./intents";
  */
 
 export function buildIntentReply(intent: TradeIntent): string {
-  const verb = intent.action === "buy" ? "deploy" : "retire";
-  const amount = intent.amount_value.toString();
-  return `Decree accepted, gladiator. Commodus shall ${verb} ${amount} USDC into ${intent.symbol}. Await the arena's judgement.`;
+  if (intent.action === "buy") {
+    return (
+      `Decree accepted, gladiator. Commodus shall deploy ${intent.amount_value} USDC into ` +
+      `${intent.symbol}. Await the arena's judgement.`
+    );
+  }
+  return (
+    `Decree accepted, gladiator. Commodus shall retire ${intent.amount_value}% of ` +
+    `${intent.symbol}. Await the arena's judgement.`
+  );
 }
 
 export type OutcomeSuccess = {
   kind: "success";
+  action: "buy" | "sell";
   symbol: string;
   quantity: number;
   notionalUsdc: number;
   txHash: string;
+  /** Gross USDC leg on buys; gross USDC received on sells (before swap fee). */
+  realizedPnlUsdc?: number;
 };
 
 export type OutcomeFailure = {
@@ -37,6 +47,21 @@ export function buildOutcomeReply(outcome: Outcome): string {
     const notional = outcome.notionalUsdc.toLocaleString("en-US", {
       maximumFractionDigits: 2,
     });
+    const pnlPart =
+      outcome.action === "sell" && outcome.realizedPnlUsdc != null
+        ? ` Realized PnL ${outcome.realizedPnlUsdc.toLocaleString("en-US", {
+            maximumFractionDigits: 2,
+            signDisplay: "exceptZero",
+          })} USDC.`
+        : "";
+
+    if (outcome.action === "sell") {
+      return (
+        `Victory. Retired ${qty} ${outcome.symbol} for ${notional} USDC gross.${pnlPart} ` +
+        `Tx ${outcome.txHash.slice(0, 10)}…`
+      );
+    }
+
     return `Victory. ${qty} ${outcome.symbol} secured for ${notional} USDC. Tx ${outcome.txHash.slice(0, 10)}…`;
   }
   return `Order failed in the arena. Reason: ${outcome.reason}.`;
@@ -53,20 +78,6 @@ export const POLICY_REJECTION_COPY: Record<PolicyRejectionReason, string> = {
     "Order denied. The decree exceeds thy allotted size for a single trade.",
   wallet_cap_usdc:
     "Order denied. Thy arena coffers have reached their cap. Withdraw before deploying more.",
+  insufficient_position:
+    "Order denied. Thy position in that asset is too small for this decree.",
 };
-
-/**
- * Non-policy templated rejection copy used by the workflow for states
- * that aren't a `PolicyRejectionReason` — features that have passed
- * every gate but are not yet fully wired.
- *
- * TODO(#10): remove `sell_not_yet_supported` once sell execution is
- *            implemented; sells should then flow through the full
- *            pipeline like buys.
- */
-export const HANDOFF_REJECTION_COPY = {
-  sell_not_yet_supported:
-    "The decree is understood, gladiator, but the arena does not yet accept sales. Return when the forges of Rome are ready.",
-} as const satisfies Record<string, string>;
-
-export type HandoffRejectionReason = keyof typeof HANDOFF_REJECTION_COPY;

--- a/lib/supabase/types.ts
+++ b/lib/supabase/types.ts
@@ -550,6 +550,8 @@ export type Database = {
           notional_usdc: number | null
           privy_transaction_id: string | null
           quantity: number | null
+          realized_pnl_usdc: number | null
+          realized_return_pct: number | null
           sponsored_gas_usdc: number | null
           status: string
           swap_fee_usdc: number | null
@@ -567,6 +569,8 @@ export type Database = {
           notional_usdc?: number | null
           privy_transaction_id?: string | null
           quantity?: number | null
+          realized_pnl_usdc?: number | null
+          realized_return_pct?: number | null
           sponsored_gas_usdc?: number | null
           status?: string
           swap_fee_usdc?: number | null
@@ -584,6 +588,8 @@ export type Database = {
           notional_usdc?: number | null
           privy_transaction_id?: string | null
           quantity?: number | null
+          realized_pnl_usdc?: number | null
+          realized_return_pct?: number | null
           sponsored_gas_usdc?: number | null
           status?: string
           swap_fee_usdc?: number | null

--- a/lib/workflows/commodus-command.ts
+++ b/lib/workflows/commodus-command.ts
@@ -1,5 +1,5 @@
 import { FatalError } from "workflow";
-import { parseUnits, type Hex } from "viem";
+import { formatUnits, parseUnits, type Hex } from "viem";
 
 import { USDC_BASE_ADDRESS, USDC_DECIMALS } from "@/lib/chain/addresses";
 import { basePublicClient } from "@/lib/chain/client";
@@ -18,7 +18,7 @@ import {
   ZeroxNotConfiguredError,
 } from "@/lib/zerox/quote";
 
-import { ensureUsdcAllowance } from "@/lib/execution/allowance";
+import { ensureErc20Allowance, ensureUsdcAllowance } from "@/lib/execution/allowance";
 import {
   submitFeeTransfer,
   OperatorTreasuryNotConfiguredError,
@@ -32,17 +32,18 @@ import {
   reserveOrLoadExecution,
   type ReservedExecution,
 } from "@/lib/execution/reserve";
+import { applyLotsAndPositionsForExecution } from "@/lib/execution/lot-persistence";
 import {
   decodeSwapReceipt,
   SwapLogMissingError,
+  type SwapDirection,
 } from "@/lib/execution/swap-logs";
 import {
   buildIntentReply,
   buildOutcomeReply,
-  HANDOFF_REJECTION_COPY,
   POLICY_REJECTION_COPY,
 } from "@/lib/execution/templates";
-import type { CommandIntent, TradeIntent } from "@/lib/execution/intents";
+import type { CommandIntent, SellIntent, TradeIntent } from "@/lib/execution/intents";
 
 /**
  * Payload forwarded from the Neynar `cast.created` webhook. Narrow by
@@ -61,8 +62,8 @@ export interface CommandContext {
  *
  * Flow (issue #8 § Workflow):
  *   load_command → parse → policy_validate → compute_fee → quote_swap →
- *   publish_intent_reply → ensure_allowance → submit_swap → transfer_fee →
- *   verify_tx → decode_swap_log → score_time_enforcement →
+ *   publish_intent_reply → ensure_allowance → submit_swap → verify_tx →
+ *   decode_swap_log → transfer_fee → score_time_enforcement →
  *   update_lots_and_positions → score_trade → publish_outcome_reply
  *
  * Every step is `'use step'` and either pure or idempotent check-then-
@@ -70,10 +71,9 @@ export interface CommandContext {
  * from the furthest-forward populated column (`tx_hash`, `confirmed_at`,
  * `cast_replies` rows, etc.).
  *
- * The happy path is fully implemented through `decode_swap_log` (#26);
- * FIFO bookkeeping (#10) / score-time price-impact (#12) / full scoring
- * are minimal placeholders with TODO markers — the replay-safety and
- * outcome-reply invariants hold regardless of how those are fleshed out.
+ * The happy path is fully implemented through `decode_swap_log` (#26)
+ * and FIFO lot accounting (#10). Score-time price-impact (#12) / full
+ * scoring beyond `trade_executed` remain minimal placeholders.
  */
 export async function handleCommodusCommand(ctx: CommandContext) {
   "use workflow";
@@ -132,24 +132,140 @@ export async function handleCommodusCommand(ctx: CommandContext) {
 
   await markStatus(ctx.castHash, "validated");
 
-  // Sell handoff — #9 reaches `policy_validate` and stops here. Full
-  // sell execution (quote, submit, FIFO lot consumption, realized PnL)
-  // is issue #10. Leaving the `TODO(#10)` markers below so the pickup
-  // PR knows what to remove.
   if (intent.action === "sell") {
-    await markRejected(ctx.castHash, "sell_not_yet_supported");
+    const sellIntent = intent;
+    const sellAssetBaseUnits = policy.context.sellAssetBaseUnits;
+    if (!sellAssetBaseUnits) {
+      throw new Error("sell pipeline: sellAssetBaseUnits missing from policy context");
+    }
+
+    const sellReservation = await quoteAndReserveSell({
+      castHash: ctx.castHash,
+      castCommandId: loaded.id,
+      ctx: policy.context,
+      intent: sellIntent,
+      sellAssetBaseUnits,
+    });
+    const sellExecutionId = sellReservation.executionId;
+
+    if (sellReservation.reservedFillUsdc <= sellReservation.feeUsdc) {
+      await markRejected(ctx.castHash, "max_trade_usdc");
+      await publishOutcomeReply(
+        ctx.castHash,
+        POLICY_REJECTION_COPY.max_trade_usdc,
+      );
+      return { status: "rejected" as const, reason: "fee_exceeds_notional" };
+    }
+
+    await markStatus(ctx.castHash, "quoted");
+
+    await publishIntentReply(ctx.castHash, buildIntentReply(sellIntent));
+
+    await ensureSellAssetAllowance({
+      ctx: policy.context,
+      spender: sellReservation.txTo,
+      sellAssetBaseUnits,
+      executionId: sellExecutionId,
+    });
+
+    const sellSubmitted: { txHash: string; privyTransactionId: string | null } =
+      sellReservation.txHash
+        ? {
+            txHash: sellReservation.txHash,
+            privyTransactionId: sellReservation.privyTransactionId,
+          }
+        : await submitSwap({
+            executionId: sellExecutionId,
+            tradeExecutionId: sellReservation.tradeExecutionId,
+            ctx: policy.context,
+            quoteTxTo: sellReservation.txTo,
+            quoteTxData: sellReservation.txData,
+            quoteTxValue: sellReservation.txValue,
+          });
+
+    await markStatus(ctx.castHash, "executing");
+
+    const sellConfirmed = sellReservation.confirmedAt
+      ? { txHash: sellSubmitted.txHash, confirmedAt: sellReservation.confirmedAt }
+      : await verifyTxOnchain({
+          tradeExecutionId: sellReservation.tradeExecutionId,
+          txHash: sellSubmitted.txHash,
+        });
+
+    const sellDecoded = await decodeSwapLog({
+      tradeExecutionId: sellReservation.tradeExecutionId,
+      txHash: sellConfirmed.txHash,
+      walletAddress: policy.context.walletAddress,
+      assetAddress: policy.context.assetAddress,
+      assetDecimals: policy.context.assetDecimals,
+      reservedFillUsdc: sellReservation.reservedFillUsdc,
+      direction: "asset_to_usdc",
+    });
+
+    if (!sellDecoded.ok) {
+      await markTradeExecutionFailed(sellReservation.tradeExecutionId);
+      await markRejected(ctx.castHash, sellDecoded.reason, "failed");
+      await publishOutcomeReply(
+        ctx.castHash,
+        buildOutcomeReply({ kind: "failure", reason: sellDecoded.reason }),
+      );
+      return { status: "failed" as const, reason: sellDecoded.reason };
+    }
+
+    await transferFeeLeg({
+      tradeExecutionId: sellReservation.tradeExecutionId,
+      walletId: policy.context.privyWalletId,
+      feeUsdc: sellReservation.feeUsdc,
+      executionId: sellExecutionId,
+    });
+
+    const sellEnforcement = await scoreTimeEnforcement({
+      tradeExecutionId: sellReservation.tradeExecutionId,
+      quotedNotional: sellReservation.reservedFillUsdc,
+      maxPriceImpactBps: policy.context.policy.maxPriceImpactBps,
+    });
+
+    if (!sellEnforcement.ok) {
+      await markRejected(ctx.castHash, sellEnforcement.reason, "failed");
+      await publishOutcomeReply(
+        ctx.castHash,
+        buildOutcomeReply({ kind: "failure", reason: sellEnforcement.reason }),
+      );
+      return { status: "failed" as const, reason: sellEnforcement.reason };
+    }
+
+    const sellPnl = await updateLotsAndPositions({
+      tradeExecutionId: sellReservation.tradeExecutionId,
+      intentAction: "sell",
+    });
+
+    await scoreTrade({
+      castCommandId: loaded.id,
+      userId: walletLookup.userId,
+      tradeExecutionId: sellReservation.tradeExecutionId,
+    });
+
+    await markStatus(ctx.castHash, "executed");
     await publishOutcomeReply(
       ctx.castHash,
-      HANDOFF_REJECTION_COPY.sell_not_yet_supported,
+      buildOutcomeReply({
+        kind: "success",
+        action: "sell",
+        symbol: sellIntent.symbol,
+        quantity: sellDecoded.quantity,
+        notionalUsdc: sellDecoded.fillUsdcHuman,
+        txHash: sellConfirmed.txHash,
+        realizedPnlUsdc: sellPnl.realizedPnlUsdc ?? undefined,
+      }),
     );
+
     return {
-      status: "rejected" as const,
-      reason: "sell_not_yet_supported" as const,
+      status: "executed" as const,
+      txHash: sellConfirmed.txHash,
+      executionId: sellExecutionId,
     };
   }
 
-  // `intent` is now narrowed to `BuyIntent` — sells branched out above
-  // and status branched out before wallet lookup.
   const feeUsdc = await computeFee({
     notionalUsdc: intent.amount_value,
     swapFeeBps: policy.context.policy.swapFeeBps,
@@ -207,13 +323,6 @@ export async function handleCommodusCommand(ctx: CommandContext) {
 
   await markStatus(ctx.castHash, "executing");
 
-  await transferFeeLeg({
-    tradeExecutionId: reservation.tradeExecutionId,
-    walletId: policy.context.privyWalletId,
-    feeUsdc,
-    executionId,
-  });
-
   const confirmed = reservation.confirmedAt
     ? { txHash: submitted.txHash, confirmedAt: reservation.confirmedAt }
     : await verifyTxOnchain({
@@ -227,7 +336,8 @@ export async function handleCommodusCommand(ctx: CommandContext) {
     walletAddress: policy.context.walletAddress,
     assetAddress: policy.context.assetAddress,
     assetDecimals: policy.context.assetDecimals,
-    reservedNotionalUsdc: netNotional,
+    reservedFillUsdc: reservation.reservedFillUsdc,
+    direction: "usdc_to_asset",
   });
 
   if (!decoded.ok) {
@@ -240,9 +350,16 @@ export async function handleCommodusCommand(ctx: CommandContext) {
     return { status: "failed" as const, reason: decoded.reason };
   }
 
+  await transferFeeLeg({
+    tradeExecutionId: reservation.tradeExecutionId,
+    walletId: policy.context.privyWalletId,
+    feeUsdc: reservation.feeUsdc,
+    executionId,
+  });
+
   const enforcement = await scoreTimeEnforcement({
     tradeExecutionId: reservation.tradeExecutionId,
-    quotedNotional: netNotional,
+    quotedNotional: reservation.reservedFillUsdc,
     maxPriceImpactBps: policy.context.policy.maxPriceImpactBps,
   });
 
@@ -257,6 +374,7 @@ export async function handleCommodusCommand(ctx: CommandContext) {
 
   await updateLotsAndPositions({
     tradeExecutionId: reservation.tradeExecutionId,
+    intentAction: "buy",
   });
   await scoreTrade({
     castCommandId: loaded.id,
@@ -269,9 +387,10 @@ export async function handleCommodusCommand(ctx: CommandContext) {
     ctx.castHash,
     buildOutcomeReply({
       kind: "success",
+      action: "buy",
       symbol: intent.symbol,
       quantity: decoded.quantity,
-      notionalUsdc: decoded.usdcSpent,
+      notionalUsdc: decoded.fillUsdcHuman,
       txHash: confirmed.txHash,
     }),
   );
@@ -432,8 +551,11 @@ type QuoteAndReserveReturn = ReservedExecution & {
   txTo: string;
   txData: string;
   txValue: string;
-  /** USDC sell amount in base units, serialized as a string (BigInt → string). */
+  /** Sell-token amount in base units, serialized as a string (BigInt → string). */
   sellAmountBaseUnits: string;
+  /** USDC anchor for decode tolerance (net swap leg on buys; gross USDC in on sells). */
+  reservedFillUsdc: number;
+  feeUsdc: number;
 };
 
 async function quoteAndReserve(params: {
@@ -490,6 +612,70 @@ async function quoteAndReserve(params: {
     txData: quote.transaction.data,
     txValue: quote.transaction.value,
     sellAmountBaseUnits: sellAmount.toString(),
+    reservedFillUsdc: params.netNotional,
+    feeUsdc: params.feeUsdc,
+  };
+}
+
+async function quoteAndReserveSell(params: {
+  castHash: string;
+  castCommandId: string;
+  ctx: PolicyContext;
+  intent: SellIntent;
+  sellAssetBaseUnits: string;
+}): Promise<QuoteAndReserveReturn> {
+  "use step";
+
+  const executionId = deriveExecutionId(params.castHash);
+
+  let quote;
+  try {
+    quote = await getAllowanceHolderQuote({
+      sellToken: params.ctx.assetAddress,
+      buyToken: USDC_BASE_ADDRESS,
+      sellAmount: params.sellAssetBaseUnits,
+      taker: params.ctx.walletAddress,
+      slippageBps: params.ctx.policy.maxSlippageBps,
+    });
+  } catch (err) {
+    if (err instanceof ZeroxNotConfiguredError) {
+      throw new FatalError(err.message);
+    }
+    throw err;
+  }
+
+  if (!quote.liquidityAvailable) {
+    throw new Error("quote_swap_sell: 0x reports no liquidity for pair");
+  }
+
+  const grossUsdcExpected = Number(
+    formatUnits(BigInt(quote.buyAmount), USDC_DECIMALS),
+  );
+
+  const feeUsdc = computeSwapFeeUsdc({
+    notionalUsdc: grossUsdcExpected,
+    swapFeeBps: params.ctx.policy.swapFeeBps,
+    swapFeeMinUsdc: params.ctx.policy.swapFeeMinUsdc,
+  });
+
+  const reservation = await reserveOrLoadExecution({
+    castCommandId: params.castCommandId,
+    ctx: params.ctx,
+    intent: params.intent,
+    executionId,
+    feeUsdc,
+    notionalUsdc: grossUsdcExpected,
+  });
+
+  return {
+    ...reservation,
+    executionId,
+    txTo: quote.transaction.to,
+    txData: quote.transaction.data,
+    txValue: quote.transaction.value,
+    sellAmountBaseUnits: params.sellAssetBaseUnits,
+    reservedFillUsdc: grossUsdcExpected,
+    feeUsdc,
   };
 }
 
@@ -531,6 +717,24 @@ async function ensureAllowanceStep(params: {
     privyWalletId: params.ctx.privyWalletId,
     spender: params.spender,
     minRequired: BigInt(params.sellAmountBaseUnits),
+    referenceId: params.executionId,
+  });
+}
+
+async function ensureSellAssetAllowance(params: {
+  ctx: PolicyContext;
+  spender: string;
+  sellAssetBaseUnits: string;
+  executionId: string;
+}): Promise<void> {
+  "use step";
+
+  await ensureErc20Allowance({
+    tokenAddress: params.ctx.assetAddress,
+    walletAddress: params.ctx.walletAddress,
+    privyWalletId: params.ctx.privyWalletId,
+    spender: params.spender,
+    minRequired: BigInt(params.sellAssetBaseUnits),
     referenceId: params.executionId,
   });
 }
@@ -718,7 +922,8 @@ type DecodeSwapLogResult =
       ok: true;
       quantity: number;
       executionPriceUsdc: number;
-      usdcSpent: number;
+      /** Realized USDC leg: spent on buys, received (gross) on sells. */
+      fillUsdcHuman: number;
     }
   | { ok: false; reason: DecodeFailureReason };
 
@@ -728,7 +933,8 @@ async function decodeSwapLog(params: {
   walletAddress: string;
   assetAddress: string;
   assetDecimals: number;
-  reservedNotionalUsdc: number;
+  reservedFillUsdc: number;
+  direction: SwapDirection;
 }): Promise<DecodeSwapLogResult> {
   "use step";
 
@@ -737,7 +943,7 @@ async function decodeSwapLog(params: {
   // is cheap on retries.
   const { data: existing, error: readErr } = await supabaseAdmin
     .from("trade_executions")
-    .select("quantity, execution_price_usdc")
+    .select("quantity, execution_price_usdc, notional_usdc")
     .eq("id", params.tradeExecutionId)
     .maybeSingle();
 
@@ -749,11 +955,15 @@ async function decodeSwapLog(params: {
     existing?.quantity != null &&
     existing?.execution_price_usdc != null
   ) {
+    const fillUsdcHuman =
+      existing.notional_usdc != null
+        ? Number(existing.notional_usdc)
+        : params.reservedFillUsdc;
     return {
       ok: true,
       quantity: Number(existing.quantity),
       executionPriceUsdc: Number(existing.execution_price_usdc),
-      usdcSpent: params.reservedNotionalUsdc,
+      fillUsdcHuman,
     };
   }
 
@@ -771,6 +981,7 @@ async function decodeSwapLog(params: {
       walletAddress: params.walletAddress,
       assetAddress: params.assetAddress,
       assetDecimals: params.assetDecimals,
+      direction: params.direction,
     });
   } catch (err) {
     if (err instanceof SwapLogMissingError) {
@@ -784,9 +995,9 @@ async function decodeSwapLog(params: {
   // realized USDC-out almost always means we're decoding the wrong tx
   // or against the wrong asset — fail fast rather than booking bad P&L.
   const tolerance =
-    (params.reservedNotionalUsdc * DECODE_TOLERANCE_BPS) / 10_000;
+    (params.reservedFillUsdc * DECODE_TOLERANCE_BPS) / 10_000;
   if (
-    Math.abs(decoded.usdcHumanNumber - params.reservedNotionalUsdc) > tolerance
+    Math.abs(decoded.usdcHumanNumber - params.reservedFillUsdc) > tolerance
   ) {
     return { ok: false, reason: "decode_log_mismatch" };
   }
@@ -798,6 +1009,7 @@ async function decodeSwapLog(params: {
     .update({
       quantity: decoded.quantity as unknown as number,
       execution_price_usdc: decoded.executionPriceUsdc as unknown as number,
+      notional_usdc: decoded.usdcHumanNumber as unknown as number,
     })
     .eq("id", params.tradeExecutionId);
 
@@ -809,7 +1021,7 @@ async function decodeSwapLog(params: {
     ok: true,
     quantity: decoded.quantityNumber,
     executionPriceUsdc: decoded.executionPriceUsdcNumber,
-    usdcSpent: decoded.usdcHumanNumber,
+    fillUsdcHuman: decoded.usdcHumanNumber,
   };
 }
 
@@ -856,13 +1068,30 @@ async function scoreTimeEnforcement(params: {
 
 async function updateLotsAndPositions(params: {
   tradeExecutionId: string;
-}): Promise<void> {
+  intentAction: "buy" | "sell";
+}): Promise<{ realizedPnlUsdc: number | null }> {
   "use step";
 
-  // TODO: realize quantity + avg_cost from swap log; insert lots row
-  // keyed on opening_execution_id (unique), upsert positions. For now
-  // intentionally a no-op; see issue #8 follow-ups.
-  return;
+  await applyLotsAndPositionsForExecution(params.tradeExecutionId);
+
+  if (params.intentAction !== "sell") {
+    return { realizedPnlUsdc: null };
+  }
+
+  const { data, error } = await supabaseAdmin
+    .from("trade_executions")
+    .select("realized_pnl_usdc")
+    .eq("id", params.tradeExecutionId)
+    .maybeSingle();
+
+  if (error) {
+    throw new Error(`update_lots_and_positions: read pnl failed: ${error.message}`);
+  }
+
+  return {
+    realizedPnlUsdc:
+      data?.realized_pnl_usdc != null ? Number(data.realized_pnl_usdc) : null,
+  };
 }
 
 // ---------------------------------------------------------------------------

--- a/lib/zerox/quote.ts
+++ b/lib/zerox/quote.ts
@@ -26,7 +26,7 @@ import { env } from "@/lib/env";
  *     current on-chain allowance and submits a MAX_UINT approval only
  *     when the wallet is under-approved.
  *   - Price vs quote distinction (we only need quote+calldata).
- *   - Sell-side sizing (MVP is buy-only; sells add post-MVP).
+ *   - Sell-side sizing — callers pass `sellToken` / `sellAmount` for asset→USDC.
  */
 
 const ZEROX_API_BASE = "https://api.0x.org";

--- a/scripts/smoke-parse.ts
+++ b/scripts/smoke-parse.ts
@@ -72,6 +72,12 @@ const CASES: ReadonlyArray<Case> = [
     expect: { kind: "ok", action: "sell" },
   },
   {
+    label: "casual sell — 'half of' (no possessive)",
+    text: "@commodus sell half of aero",
+    path: "llm",
+    expect: { kind: "ok", action: "sell" },
+  },
+  {
     label: "casual sell — 'N% of my'",
     text: "@commodus sell 25% of my aero",
     path: "llm",

--- a/supabase/migrations/20260419210000_trade_executions_realized_pnl.sql
+++ b/supabase/migrations/20260419210000_trade_executions_realized_pnl.sql
@@ -1,0 +1,13 @@
+-- Issue #10: realized P&L on the closing trade_executions row (sells).
+
+alter table public.trade_executions
+  add column realized_pnl_usdc   numeric(38, 18),
+  add column realized_return_pct numeric(38, 18);
+
+comment on column public.trade_executions.realized_pnl_usdc is
+  'Aggregate realized profit/loss in USDC for a sell execution (FIFO), '
+  'after swap fee on proceeds. Buys leave this null.';
+
+comment on column public.trade_executions.realized_return_pct is
+  'realized_pnl_usdc / total cost basis of lots closed × 100. Null when '
+  'no cost basis was closed.';


### PR DESCRIPTION
## Summary

Implements [issue #10](https://github.com/hurley87/victus/issues/10): custodial **sell** execution, **FIFO** lot consumption with `lot_closures`, **realized PnL** on `trade_executions`, and outcome reply copy. Buys insert `lots` with **avg cost** including swap fee + sponsored gas; `positions` stay in sync.

## Details

- Sell: 0x asset→USDC, `ensureErc20Allowance`, workflow mirrors buy through submit → **verify → decode → fee** (fee after swap confirms).
- `decodeSwapReceipt` supports `asset_to_usdc`; `notional_usdc` stores realized USDC leg after decode.
- `lib/execution/lot-accounting.ts` (unit tests) + `lot-persistence.ts` for idempotent DB writes.
- Migration: `realized_pnl_usdc`, `realized_return_pct` on `trade_executions` (apply via Supabase CLI/MCP in each env).
- Policy: `insufficient_position` when sell size rounds to zero or no position.
- `scripts/smoke-parse.ts`: LLM case for `@commodus sell half of aero`.

Closes #10

Made with [Cursor](https://cursor.com)