### PR TITLE
feat(execution): scoring & submission hardening (#12)

### DIFF
--- a/lib/commodus-voice.ts
+++ b/lib/commodus-voice.ts
@@ -1,0 +1,38 @@
+/**
+ * Commodus outcome copy for execution-time failures (#12).
+ *
+ * Maps `trade_executions.failure_reason` and decode/policy codes to short,
+ * in-voice lines. Unknown codes fall back to a generic arena failure line.
+ */
+
+const CHAIN_REJECTED_SWAP =
+  "Order failed in the arena. Reason: the chain rejected the swap.";
+
+export const EXECUTION_FAILURE_VOICE: Record<string, string> = {
+  oversize: "Order failed in the arena. Reason: the decree exceeded thy single-trade limit.",
+  wallet_cap: "Order failed in the arena. Reason: thy arena coffers exceed their cap.",
+  insufficient_balance:
+    "Order failed in the arena. Reason: insufficient balance for that decree.",
+  daily_rate_limit:
+    "Order failed in the arena. Reason: thy daily allotment of decrees is spent.",
+  needs_gladiator_mint:
+    "Order failed in the arena. Reason: mint thy gladiator before trading.",
+  non_whitelisted_token:
+    "Order failed in the arena. Reason: a token in the fill is not approved for this arena.",
+  price_impact:
+    "Order failed in the arena. Reason: price moved too sharply against thee.",
+  revert: CHAIN_REJECTED_SWAP,
+  reverted: CHAIN_REJECTED_SWAP,
+  decode_log_missing:
+    "Order failed in the arena. Reason: the arena could not read the swap receipt.",
+  decode_log_mismatch:
+    "Order failed in the arena. Reason: the fill did not match the quoted path.",
+  unknown: "Order failed in the arena. Reason: unknown.",
+};
+
+export function voiceForExecutionFailure(reason: string): string {
+  return (
+    EXECUTION_FAILURE_VOICE[reason] ??
+    `Order failed in the arena. Reason: ${reason}.`
+  );
+}

--- a/lib/commodus/parser.test.ts
+++ b/lib/commodus/parser.test.ts
@@ -1,11 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import {
-  ALLOWED_SYMBOL,
-  MAX_USDC_AMOUNT,
-  normalizeCommandText,
-  parseCommand,
-} from "./parser";
+import { MAX_USDC_AMOUNT, normalizeCommandText, parseCommand } from "./parser";
 
 describe("normalizeCommandText", () => {
   it("lowercases, strips @handle, collapses whitespace", () => {
@@ -15,8 +10,6 @@ describe("normalizeCommandText", () => {
   });
 
   it("is handle-agnostic (works with @commo, @commodus, or future handles)", () => {
-    // Neynar's subscription filter routes the cast to us, so the handle
-    // token can be anything; we strip it uniformly.
     expect(normalizeCommandText("@commo buy 5 usdc of aero")).toBe(
       "buy 5 usdc of aero",
     );
@@ -42,7 +35,16 @@ describe("parseCommand — happy path", () => {
     expect(parseCommand("@commo buy 5 usdc of aero")).toEqual({
       kind: "ok",
       action: "buy",
-      symbol: ALLOWED_SYMBOL,
+      symbol: "AERO",
+      amount: 5,
+    });
+  });
+
+  it("accepts any conventional ticker symbol (whitelist is async)", () => {
+    expect(parseCommand("@commo buy 5 usdc of degen")).toEqual({
+      kind: "ok",
+      action: "buy",
+      symbol: "DEGEN",
       amount: 5,
     });
   });
@@ -51,19 +53,17 @@ describe("parseCommand — happy path", () => {
     expect(parseCommand("@commo buy 2.5 usdc of aero")).toEqual({
       kind: "ok",
       action: "buy",
-      symbol: ALLOWED_SYMBOL,
+      symbol: "AERO",
       amount: 2.5,
     });
   });
 
-  it("accepts the exact cap (boundary = MAX_USDC_AMOUNT)", () => {
-    expect(parseCommand(`@commo buy ${MAX_USDC_AMOUNT} usdc of aero`)).toMatchObject({
+  it("accepts amounts above the default policy cap (policy enforces later)", () => {
+    expect(parseCommand(`@commo buy ${MAX_USDC_AMOUNT + 1} usdc of aero`)).toEqual({
       kind: "ok",
-      amount: MAX_USDC_AMOUNT,
-    });
-    expect(parseCommand(`@commo buy ${MAX_USDC_AMOUNT}.0 usdc of aero`)).toMatchObject({
-      kind: "ok",
-      amount: MAX_USDC_AMOUNT,
+      action: "buy",
+      symbol: "AERO",
+      amount: MAX_USDC_AMOUNT + 1,
     });
   });
 
@@ -71,6 +71,7 @@ describe("parseCommand — happy path", () => {
     expect(parseCommand("@Commo BUY 5 USDC OF AERO")).toMatchObject({
       kind: "ok",
       amount: 5,
+      symbol: "AERO",
     });
   });
 
@@ -139,10 +140,7 @@ describe("parseCommand — grammar rejections", () => {
     });
   });
 
-  it("rejects sell and status verbs at the regex layer (handled by the LLM fallback in #9)", () => {
-    // Stage 1 is a strict AERO-buy regex; sell and status verbs miss
-    // the pattern here and are routed to `parseCommandIntent`'s LLM
-    // fallback. See `lib/execution/parse.ts` + `llm-parse.ts`.
+  it("rejects sell and status verbs at the regex layer (handled by the LLM fallback)", () => {
     expect(parseCommand("@commo sell 100% of aero")).toEqual({
       kind: "grammar_error",
     });
@@ -153,40 +151,5 @@ describe("parseCommand — grammar rejections", () => {
     expect(
       parseCommand("@commo buy 5 usdc of aero; buy 3 usdc of aero"),
     ).toEqual({ kind: "grammar_error" });
-  });
-});
-
-describe("parseCommand — asset rejections", () => {
-  it("rejects a structurally-valid command with a non-AERO symbol", () => {
-    expect(parseCommand("@commo buy 5 usdc of weth")).toEqual({
-      kind: "asset_error",
-      action: "buy",
-      attemptedSymbol: "WETH",
-      amount: 5,
-    });
-  });
-
-  it("prefers asset rejection over oversize when both apply", () => {
-    // We rank structural/whitelist failures above policy failures so users
-    // aren't told "too big" about an asset we wouldn't honor at any size.
-    expect(parseCommand("@commo buy 100 usdc of weth")).toMatchObject({
-      kind: "asset_error",
-      attemptedSymbol: "WETH",
-    });
-  });
-});
-
-describe("parseCommand — oversize rejections", () => {
-  it("rejects amounts just over the cap", () => {
-    expect(parseCommand("@commo buy 11 usdc of aero")).toEqual({
-      kind: "oversize_error",
-      action: "buy",
-      symbol: ALLOWED_SYMBOL,
-      amount: 11,
-    });
-    expect(parseCommand("@commo buy 10.01 usdc of aero")).toMatchObject({
-      kind: "oversize_error",
-      amount: 10.01,
-    });
   });
 });

--- a/lib/commodus/parser.ts
+++ b/lib/commodus/parser.ts
@@ -1,49 +1,30 @@
 /**
  * Pure, unit-testable parser for `@commodus` trade commands.
  *
- * Scope (issue #6, "tracer" slice):
- *  - One action: `buy`
- *  - One asset: AERO (hardcoded; full whitelist lookup arrives in #9/#12)
- *  - One amount type: USDC-in
- *  - One size cap: ≤ 10 USDC (hardcoded; per-wallet policy arrives in #12)
- *
- * Anything outside those constraints resolves to a discriminated rejection
- * so the workflow can branch on a single switch. The DB-backed arena-wallet
- * check is intentionally not performed here — it needs a round-trip and
- * must stay out of the pure parser so it remains trivially testable.
+ * Stage-1 regex matches canonical `buy AMOUNT usdc of SYMBOL` commands.
+ * Symbol whitelist and `max_trade_usdc` enforcement run in async
+ * `parseCommandIntent` / `policy_validate` (#12) so policy DB values are
+ * the single source of truth for caps.
  */
 
-/** Hardcoded for this slice. Full whitelist lookup lands in #9/#12. */
-export const ALLOWED_SYMBOL = "AERO" as const;
-
-/** Hardcoded for this slice. Per-wallet `wallet_policies` lookup lands in #12. */
+/** Default `max_trade_usdc` (policy is authoritative); kept for tests. */
 export const MAX_USDC_AMOUNT = 10;
 
 export type ParseResult =
   | {
       kind: "ok";
       action: "buy";
-      symbol: typeof ALLOWED_SYMBOL;
+      symbol: string;
       amount: number;
     }
-  | { kind: "grammar_error" }
-  | { kind: "asset_error"; action: "buy"; attemptedSymbol: string; amount: number }
-  | {
-      kind: "oversize_error";
-      action: "buy";
-      symbol: typeof ALLOWED_SYMBOL;
-      amount: number;
-    };
+  | { kind: "grammar_error" };
 
 /**
  * Matches a normalized command of the form `buy AMOUNT usdc of SYMBOL`.
  *
- * AMOUNT is a positive decimal with at least one integer digit (leading
- * `.` like `.5` is rejected as grammar — forces users to write `0.5`, which
- * then also fails the positive-decimal check). SYMBOL is any token matching
- * the conventional ticker shape; asset-whitelist filtering happens after
- * the regex matches so we can distinguish "you typed gibberish" from "you
- * typed a symbol we don't trade yet".
+ * SYMBOL is any conventional ticker; whitelist filtering is async in
+ * `parseCommandIntent` so users get `asset_error` with templated copy
+ * rather than a grammar miss.
  */
 const COMMAND_REGEX =
   /^buy\s+([0-9]+(?:\.[0-9]+)?)\s+usdc\s+of\s+([a-z][a-z0-9]*)\s*$/u;
@@ -65,10 +46,10 @@ const MENTION_REGEX = /@[a-z0-9_-]+/giu;
  * Normalize a raw cast text into a canonical command string.
  *
  * Steps, in order:
- *  1. Lowercase (grammar is case-insensitive per AC).
- *  2. Strip any `@handle` mention token so the regex can anchor on `buy`.
- *  3. Collapse Unicode whitespace (tabs, NBSP, doubled spaces, newlines).
- *  4. Trim.
+ *   1. Lowercase (grammar is case-insensitive per AC).
+ *   2. Strip any `@handle` mention token so the regex can anchor on `buy`.
+ *   3. Collapse Unicode whitespace (tabs, NBSP, doubled spaces, newlines).
+ *   4. Trim.
  *
  * Done as a separate export so tests can exercise the normalization step
  * directly without going through the discriminated-union result shape.
@@ -84,17 +65,9 @@ export function normalizeCommandText(text: string): string {
 /**
  * Parse a raw `@commodus` cast text into a {@link ParseResult}.
  *
- * Rejection priority is structural → asset → size:
- *  1. Unmatched grammar → `grammar_error`.
- *  2. Matched grammar with non-AERO symbol → `asset_error` (we know what
- *     the user wanted; it's just not tradable in this arena yet).
- *  3. Matched grammar with AERO but amount > cap → `oversize_error`.
- *
- * A matched-but-zero-or-negative amount is impossible given the regex
- * (`-` is not allowed, and `0` with no decimal is technically a match of
- * `0`) — so we still guard explicitly by requiring amount > 0 after
- * numeric parsing. That turns `buy 0 usdc of aero` and `buy 0.0 ...` into
- * grammar errors, which is the intended "positive decimal" semantic.
+ * Unmatched grammar → `grammar_error`. Matched buys return `ok` with an
+ * uppercased symbol; oversize and whitelist failures are handled later
+ * in the durable pipeline.
  */
 export function parseCommand(text: string): ParseResult {
   const normalized = normalizeCommandText(text);
@@ -111,28 +84,10 @@ export function parseCommand(text: string): ParseResult {
 
   const symbol = match[2].toUpperCase();
 
-  if (symbol !== ALLOWED_SYMBOL) {
-    return {
-      kind: "asset_error",
-      action: "buy",
-      attemptedSymbol: symbol,
-      amount,
-    };
-  }
-
-  if (amount > MAX_USDC_AMOUNT) {
-    return {
-      kind: "oversize_error",
-      action: "buy",
-      symbol: ALLOWED_SYMBOL,
-      amount,
-    };
-  }
-
   return {
     kind: "ok",
     action: "buy",
-    symbol: ALLOWED_SYMBOL,
+    symbol,
     amount,
   };
 }

--- a/lib/commodus/templates.ts
+++ b/lib/commodus/templates.ts
@@ -34,8 +34,8 @@ export const REJECTION_REPLIES: Record<RejectionReason, string> = {
  * `2.5 → "2.5"`), so we intentionally avoid locale-aware formatting to
  * keep the output stable across runtimes.
  */
-export function buildAcceptedReply(amount: number): string {
-  return `Order accepted. ${amount.toString()} USDC deployed into AERO.`;
+export function buildAcceptedReply(amount: number, symbol: string): string {
+  return `Order accepted. ${amount.toString()} USDC deployed into ${symbol}.`;
 }
 
 /**
@@ -48,9 +48,5 @@ export function rejectionReasonForParse(
   switch (result.kind) {
     case "grammar_error":
       return "grammar";
-    case "asset_error":
-      return "non_whitelisted_token";
-    case "oversize_error":
-      return "oversize";
   }
 }

--- a/lib/execution/parse.ts
+++ b/lib/execution/parse.ts
@@ -7,6 +7,7 @@ import {
 } from "@/lib/commodus/parser";
 
 import type { CommandIntent } from "./intents";
+import { isTradableCommandSymbol } from "./policy";
 import {
   parseCommandIntentWithLlm,
   type ParseWithLlmOptions,
@@ -16,14 +17,10 @@ import {
  * Two-stage parser for the `parse_command` workflow step.
  *
  * Stage 1 — regex pre-filter (`lib/commodus/parser.ts`).
- *   The canonical AERO buy path (`buy N usdc of aero`) is matched
- *   without any LLM call and returns a buy `CommandIntent` directly.
- *   Grammar mismatches fall through to Stage 2. Structurally-valid
- *   buys that fail the hardcoded whitelist / size heuristics
- *   (`asset_error`, `oversize_error`) short-circuit here — the
- *   parser is the right layer to surface "you typed a real command
- *   but it's not tradable", and `policy_validate` will redundantly
- *   reject the same cases for LLM-parsed variants.
+ *   Canonical buys (`buy N usdc of symbol`) match without an LLM call.
+ *   Whitelist validation for the extracted symbol is async against
+ *   `asset_whitelist` (#12) so GLORY / unknown tickers get templated
+ *   `asset_error` without publishing an intent reply.
  *
  * Stage 2 — Vercel AI SDK fallback (`llm-parse.ts`).
  *   Handles casual phrasings for buy/sell/status that the regex
@@ -36,10 +33,7 @@ import {
  * outcome replies.
  */
 
-export type ParseReason =
-  | "grammar_error"
-  | "asset_error"
-  | "oversize_error";
+export type ParseReason = "grammar_error" | "asset_error";
 
 export type ParseCommandOutcome =
   | { ok: true; intent: CommandIntent }
@@ -57,6 +51,9 @@ export async function parseCommandIntent(
   const regex = parseCommand(text);
 
   if (regex.kind === "ok") {
+    if (!(await isTradableCommandSymbol(regex.symbol))) {
+      return { ok: false, reason: "asset_error", raw: regex };
+    }
     return {
       ok: true,
       intent: {
@@ -68,13 +65,16 @@ export async function parseCommandIntent(
     };
   }
 
-  if (regex.kind === "asset_error" || regex.kind === "oversize_error") {
-    return { ok: false, reason: regex.kind, raw: regex };
-  }
-
   const normalized = normalizeCommandText(text);
   const llm = await parseCommandIntentWithLlm(normalized, opts.llm);
-  if (llm.ok) return { ok: true, intent: llm.intent };
+  if (llm.ok) {
+    if (llm.intent.action === "buy" || llm.intent.action === "sell") {
+      if (!(await isTradableCommandSymbol(llm.intent.symbol))) {
+        return { ok: false, reason: "asset_error", raw: regex };
+      }
+    }
+    return { ok: true, intent: llm.intent };
+  }
 
   return { ok: false, reason: "grammar_error", raw: regex };
 }

--- a/lib/execution/policy.ts
+++ b/lib/execution/policy.ts
@@ -1,9 +1,11 @@
 import "server-only";
 
-import { parseUnits, type Address, getAddress } from "viem";
+import { formatUnits, type Address, getAddress } from "viem";
 
-import { readUsdcBalance } from "@/lib/chain/erc20";
+import { readErc20Balance, readUsdcBalance } from "@/lib/chain/erc20";
+import { USDC_BASE_ADDRESS, USDC_DECIMALS } from "@/lib/chain/addresses";
 import { supabaseAdmin } from "@/lib/supabase/server";
+import { getAllowanceHolderQuote } from "@/lib/zerox/quote";
 
 import type { TradeIntent } from "./intents";
 
@@ -14,20 +16,18 @@ import type { TradeIntent } from "./intents";
  * the rejection reason on `cast_commands.error_reason` and publishes
  * the matching outcome-reply template.
  *
- * Order (PRD § Execution Rules, issue #8):
- *   1. gladiator_alive      — requires an `alive` gladiator
+ * Order (PRD § Execution Rules, issue #8 / #12):
+ *   1. gladiator_alive       — requires an `alive` gladiator
  *   2. asset_not_whitelisted — symbol must be active + tradable + not blocklisted
- *   3. max_trades_per_day   — slot count for the UTC day
- *   4. max_trade_usdc       — size cap (buys only)
- *   5. wallet_cap_usdc      — live arena-wallet USDC via viem (buys only)
- *   6. insufficient_position — sells: DB position missing, zero-size, or
- *                              computed sell amount rounds to zero on-chain
+ *   3. max_trades_per_day    — completed swaps since 00:00 UTC
+ *   4. max_trade_usdc        — size cap (buys only)
+ *   5. wallet_cap_usdc       — live USDC + mark-to-0x of on-chain holdings (buys only)
+ *   6. insufficient_balance  — sells: live ERC-20 balance × percent rounds to zero
  *
- * Per-intent-type rules apply only where stated: sell intents skip
- * size and wallet-cap checks (sells pay out USDC; they don't consume it).
+ * Sell sizing uses **on-chain** balances (viem), never cached `positions`.
  *
- * The validator is side-effect-free aside from the live chain read —
- * callers update `cast_commands.status` based on the returned result.
+ * The validator may call 0x for valuation — same availability as the
+ * quote step (requires `ZEROX_API_KEY`).
  */
 
 export type PolicyRejectionReason =
@@ -36,7 +36,7 @@ export type PolicyRejectionReason =
   | "max_trades_per_day"
   | "max_trade_usdc"
   | "wallet_cap_usdc"
-  | "insufficient_position";
+  | "insufficient_balance";
 
 export type PolicyResult =
   | { ok: true; context: PolicyContext }
@@ -54,7 +54,7 @@ export type PolicyContext = {
   assetAddress: Address;
   assetDecimals: number;
   /**
-   * Sells only — exact asset base units computed from `positions.quantity`
+   * Sells only — exact asset base units computed from **on-chain** balance
    * × percent (integer 1–100), floored, used as the 0x `sellAmount`.
    */
   sellAssetBaseUnits?: string;
@@ -77,6 +77,12 @@ export type PolicyValidateParams = {
   intent: TradeIntent;
 };
 
+/** True when `symbol` is active, tradable, and not blocklisted in `asset_whitelist`. */
+export async function isTradableCommandSymbol(symbol: string): Promise<boolean> {
+  const row = await loadWhitelistedAsset(symbol);
+  return row != null;
+}
+
 export async function validatePolicy(
   params: PolicyValidateParams,
 ): Promise<PolicyResult> {
@@ -88,7 +94,7 @@ export async function validatePolicy(
 
   const policy = await loadPolicy(params.walletId);
 
-  const tradesToday = await countTradesToday(params.walletId);
+  const tradesToday = await countCompletedSwapsTodayUtc(params.walletId);
   if (tradesToday >= policy.maxTradesPerDay) {
     return { ok: false, reason: "max_trades_per_day" };
   }
@@ -101,43 +107,37 @@ export async function validatePolicy(
   }
 
   if (isBuy) {
-    const live = await readUsdcBalance(getAddress(params.walletAddress));
-    // Cap is a ceiling on arena USDC — a buy that would leave the
-    // wallet over-capped is rejected *before* the trade, so deposits
-    // can't be pre-staged to cheat the cap.
-    if (live > policy.walletCapUsdc) {
+    const wallet = getAddress(params.walletAddress);
+    const live = await readUsdcBalance(wallet);
+    const heldUsdc = await sumOnChainHoldingsUsdcViaZerox({
+      walletAddress: wallet,
+      slippageBps: policy.maxSlippageBps,
+    });
+    const exposure = live + heldUsdc;
+    if (exposure > policy.walletCapUsdc) {
       return { ok: false, reason: "wallet_cap_usdc" };
     }
   }
 
   let sellAssetBaseUnits: string | undefined;
   if (!isBuy) {
-    const position = await loadPositionQuantity(
-      params.walletId,
-      params.intent.symbol,
-    );
-    if (!position) {
-      return { ok: false, reason: "insufficient_position" };
-    }
-
+    const wallet = getAddress(params.walletAddress);
+    const token = getAddress(asset.address);
     let positionWei: bigint;
     try {
-      positionWei = parseUnits(
-        String(position.quantity).trim(),
-        asset.decimals,
-      );
+      positionWei = await readErc20Balance(token, wallet);
     } catch {
-      return { ok: false, reason: "insufficient_position" };
+      return { ok: false, reason: "insufficient_balance" };
     }
 
     if (positionWei <= BigInt(0)) {
-      return { ok: false, reason: "insufficient_position" };
+      return { ok: false, reason: "insufficient_balance" };
     }
 
     const sellWei =
       (positionWei * BigInt(params.intent.amount_value)) / BigInt(100);
     if (sellWei <= BigInt(0)) {
-      return { ok: false, reason: "insufficient_position" };
+      return { ok: false, reason: "insufficient_balance" };
     }
 
     sellAssetBaseUnits = sellWei.toString();
@@ -201,22 +201,28 @@ async function loadWhitelistedAsset(
   };
 }
 
-async function countTradesToday(walletId: string): Promise<number> {
+/**
+ * Count trades whose `cast_commands` row reached `executed` today (UTC),
+ * joined from `trade_intents`. Parse/policy rejections never get that far;
+ * score-time failures leave the cast in `failed`, so they do not consume
+ * the daily quota.
+ */
+async function countCompletedSwapsTodayUtc(walletId: string): Promise<number> {
   const startOfDayUtc = new Date();
   startOfDayUtc.setUTCHours(0, 0, 0, 0);
 
   const { count, error } = await supabaseAdmin
     .from("trade_intents")
-    .select("id", { head: true, count: "exact" })
+    .select("id, cast_commands!inner(status, updated_at)", {
+      head: true,
+      count: "exact",
+    })
     .eq("wallet_id", walletId)
-    .neq("status", "rejected")
-    .gte("created_at", startOfDayUtc.toISOString());
+    .eq("cast_commands.status", "executed")
+    .gte("cast_commands.updated_at", startOfDayUtc.toISOString());
 
   if (error) {
-    // Fail open on a read error — loudly logged so it shows up in
-    // telemetry. Failing closed would let an ops blip silently refuse
-    // every trade.
-    console.error("policy.countTradesToday failed", error);
+    console.error("policy.countCompletedSwapsTodayUtc", error);
     return 0;
   }
 
@@ -224,28 +230,6 @@ async function countTradesToday(walletId: string): Promise<number> {
 }
 
 type PolicyRow = PolicyContext["policy"];
-
-async function loadPositionQuantity(
-  walletId: string,
-  assetSymbol: string,
-): Promise<{ quantity: string } | null> {
-  const { data, error } = await supabaseAdmin
-    .from("positions")
-    .select("quantity")
-    .eq("wallet_id", walletId)
-    .eq("asset_symbol", assetSymbol)
-    .maybeSingle();
-
-  if (error) {
-    throw new Error(`positions lookup failed: ${error.message}`);
-  }
-  if (!data) return null;
-
-  const qty = String(data.quantity).trim();
-  if (!qty || Number(qty) <= 0) return null;
-
-  return { quantity: qty };
-}
 
 async function loadPolicy(walletId: string): Promise<PolicyRow> {
   const { data, error } = await supabaseAdmin
@@ -268,4 +252,55 @@ async function loadPolicy(walletId: string): Promise<PolicyRow> {
     swapFeeBps: data.swap_fee_bps,
     swapFeeMinUsdc: Number(data.swap_fee_min_usdc),
   };
+}
+
+async function loadTradableAssetRows(): Promise<
+  { address: string; decimals: number }[]
+> {
+  const { data, error } = await supabaseAdmin
+    .from("asset_whitelist")
+    .select("address, decimals")
+    .eq("is_tradable", true)
+    .eq("active", true)
+    .eq("is_blocklisted", false);
+
+  if (error) {
+    throw new Error(`asset_whitelist tradable load failed: ${error.message}`);
+  }
+
+  return data ?? [];
+}
+
+/**
+ * Marks each non-USDC tradable token holding to USDC via a fresh 0x quote
+ * (same semantics as a spot valuation at policy time).
+ */
+async function sumOnChainHoldingsUsdcViaZerox(params: {
+  walletAddress: Address;
+  slippageBps: number;
+}): Promise<number> {
+  const rows = await loadTradableAssetRows();
+  let sum = 0;
+
+  for (const row of rows) {
+    const token = getAddress(row.address);
+    if (token === USDC_BASE_ADDRESS) continue;
+
+    const bal = await readErc20Balance(token, params.walletAddress);
+    if (bal <= BigInt(0)) continue;
+
+    const quote = await getAllowanceHolderQuote({
+      sellToken: token,
+      buyToken: USDC_BASE_ADDRESS,
+      sellAmount: bal.toString(),
+      taker: params.walletAddress,
+      slippageBps: params.slippageBps,
+    });
+
+    if (!quote.liquidityAvailable) continue;
+
+    sum += Number(formatUnits(BigInt(quote.buyAmount), USDC_DECIMALS));
+  }
+
+  return sum;
 }

--- a/lib/execution/swap-logs.test.ts
+++ b/lib/execution/swap-logs.test.ts
@@ -15,6 +15,7 @@ import { USDC_BASE_ADDRESS } from "@/lib/chain/addresses";
 import {
   SwapLogMissingError,
   decodeSwapReceipt,
+  findDisallowedWalletTokens,
   type SwapReceiptLike,
 } from "./swap-logs";
 
@@ -314,5 +315,59 @@ describe("decodeSwapReceipt — sell (asset_to_usdc)", () => {
     expect(decoded.assetBaseUnits).toBe(aeroSold);
     expect(decoded.quantity).toBe("0.8214");
     expect(decoded.usdcHumanNumber).toBeCloseTo(1, 6);
+  });
+});
+
+describe("findDisallowedWalletTokens", () => {
+  it("returns empty when only USDC and the intent asset touch the wallet", () => {
+    const receipt = makeReceipt([
+      makeTransferLog({
+        token: USDC_BASE_ADDRESS,
+        from: ARENA_WALLET,
+        to: POOL_ONE,
+        value: BigInt(1_000_000),
+        logIndex: 0,
+      }),
+      makeTransferLog({
+        token: AERO_ADDRESS,
+        from: POOL_ONE,
+        to: ARENA_WALLET,
+        value: BigInt("821400000000000000"),
+        logIndex: 1,
+      }),
+    ]);
+
+    expect(
+      findDisallowedWalletTokens(receipt, ARENA_WALLET, AERO_ADDRESS),
+    ).toEqual([]);
+  });
+
+  it("flags a third ERC-20 with non-zero net flow to the wallet", () => {
+    const receipt = makeReceipt([
+      makeTransferLog({
+        token: DEGEN_ADDRESS,
+        from: POOL_TWO,
+        to: ARENA_WALLET,
+        value: BigInt(1000),
+        logIndex: 0,
+      }),
+      makeTransferLog({
+        token: USDC_BASE_ADDRESS,
+        from: ARENA_WALLET,
+        to: POOL_ONE,
+        value: BigInt(1_000_000),
+        logIndex: 1,
+      }),
+      makeTransferLog({
+        token: AERO_ADDRESS,
+        from: POOL_ONE,
+        to: ARENA_WALLET,
+        value: BigInt("821400000000000000"),
+        logIndex: 2,
+      }),
+    ]);
+
+    const bad = findDisallowedWalletTokens(receipt, ARENA_WALLET, AERO_ADDRESS);
+    expect(bad).toEqual([DEGEN_ADDRESS]);
   });
 });

--- a/lib/execution/swap-logs.ts
+++ b/lib/execution/swap-logs.ts
@@ -85,6 +85,62 @@ export class SwapLogMissingError extends Error {
   }
 }
 
+/**
+ * Every ERC-20 for which the arena wallet has a non-zero net transfer
+ * delta must be USDC or the intent asset; any other token implies an
+ * unexpected leg (score-time `non_whitelisted_token`).
+ */
+export function findDisallowedWalletTokens(
+  receipt: SwapReceiptLike,
+  walletAddress: string,
+  allowedAsset: Address,
+): Address[] {
+  const wallet = getAddress(walletAddress);
+  const usdc = USDC_BASE_ADDRESS;
+  const asset = getAddress(allowedAsset);
+
+  const transfers = parseEventLogs({
+    abi: erc20Abi,
+    eventName: "Transfer",
+    logs: [...receipt.logs],
+    strict: false,
+  });
+
+  const netByToken = new Map<string, bigint>();
+  const bump = (token: Address, delta: bigint) => {
+    const key = token;
+    netByToken.set(key, (netByToken.get(key) ?? BigInt(0)) + delta);
+  };
+
+  for (const log of transfers) {
+    const token = safeGetAddress(log.address);
+    if (!token) continue;
+
+    const args = log.args as {
+      from?: Address;
+      to?: Address;
+      value?: bigint;
+    };
+    const from = args.from ? safeGetAddress(args.from) : null;
+    const to = args.to ? safeGetAddress(args.to) : null;
+    const value = args.value;
+    if (value === undefined || from === null || to === null) continue;
+
+    if (from === wallet) bump(token, -value);
+    if (to === wallet) bump(token, value);
+  }
+
+  const disallowed: Address[] = [];
+  for (const [token, net] of netByToken) {
+    if (net === BigInt(0)) continue;
+    const addr = token as Address;
+    if (addr === usdc || addr === asset) continue;
+    disallowed.push(addr);
+  }
+
+  return disallowed;
+}
+
 /** Price-precision floor for the `numeric(38, 18)` column. */
 const PRICE_FRACTION_DIGITS = 18;
 

--- a/lib/execution/templates.test.ts
+++ b/lib/execution/templates.test.ts
@@ -48,10 +48,10 @@ describe("buildOutcomeReply", () => {
     expect(text).toContain("0x01234567");
   });
 
-  it("renders the failure reason for a failed trade", () => {
-    const text = buildOutcomeReply({ kind: "failure", reason: "reverted" });
+  it("renders templated voice for a failed trade", () => {
+    const text = buildOutcomeReply({ kind: "failure", reason: "revert" });
     expect(text).toContain("failed");
-    expect(text).toContain("reverted");
+    expect(text).toContain("chain");
   });
 });
 
@@ -64,7 +64,7 @@ describe("POLICY_REJECTION_COPY", () => {
     expect(POLICY_REJECTION_COPY.max_trades_per_day).toBeTruthy();
     expect(POLICY_REJECTION_COPY.max_trade_usdc).toBeTruthy();
     expect(POLICY_REJECTION_COPY.wallet_cap_usdc).toBeTruthy();
-    expect(POLICY_REJECTION_COPY.insufficient_position).toBeTruthy();
+    expect(POLICY_REJECTION_COPY.insufficient_balance).toBeTruthy();
   });
 
   it("includes realized PnL on sell success outcomes", () => {

--- a/lib/execution/templates.ts
+++ b/lib/execution/templates.ts
@@ -1,3 +1,5 @@
+import { voiceForExecutionFailure } from "@/lib/commodus-voice";
+
 import type { PolicyRejectionReason } from "./policy";
 import type { TradeIntent } from "./intents";
 
@@ -64,7 +66,7 @@ export function buildOutcomeReply(outcome: Outcome): string {
 
     return `Victory. ${qty} ${outcome.symbol} secured for ${notional} USDC. Tx ${outcome.txHash.slice(0, 10)}…`;
   }
-  return `Order failed in the arena. Reason: ${outcome.reason}.`;
+  return voiceForExecutionFailure(outcome.reason);
 }
 
 export const POLICY_REJECTION_COPY: Record<PolicyRejectionReason, string> = {
@@ -78,6 +80,6 @@ export const POLICY_REJECTION_COPY: Record<PolicyRejectionReason, string> = {
     "Order denied. The decree exceeds thy allotted size for a single trade.",
   wallet_cap_usdc:
     "Order denied. Thy arena coffers have reached their cap. Withdraw before deploying more.",
-  insufficient_position:
+  insufficient_balance:
     "Order denied. Thy position in that asset is too small for this decree.",
 };

--- a/lib/supabase/types.ts
+++ b/lib/supabase/types.ts
@@ -545,6 +545,7 @@ export type Database = {
           created_at: string
           execution_id: string
           execution_price_usdc: number | null
+          failure_reason: string | null
           fee_tx_hash: string | null
           id: string
           notional_usdc: number | null
@@ -564,6 +565,7 @@ export type Database = {
           created_at?: string
           execution_id: string
           execution_price_usdc?: number | null
+          failure_reason?: string | null
           fee_tx_hash?: string | null
           id?: string
           notional_usdc?: number | null
@@ -583,6 +585,7 @@ export type Database = {
           created_at?: string
           execution_id?: string
           execution_price_usdc?: number | null
+          failure_reason?: string | null
           fee_tx_hash?: string | null
           id?: string
           notional_usdc?: number | null

--- a/lib/workflows/commodus-command.ts
+++ b/lib/workflows/commodus-command.ts
@@ -1,5 +1,11 @@
 import { FatalError } from "workflow";
-import { formatUnits, parseUnits, type Hex } from "viem";
+import {
+  formatUnits,
+  getAddress,
+  parseUnits,
+  type Address,
+  type Hex,
+} from "viem";
 
 import { USDC_BASE_ADDRESS, USDC_DECIMALS } from "@/lib/chain/addresses";
 import { basePublicClient } from "@/lib/chain/client";
@@ -16,6 +22,7 @@ import { supabaseAdmin } from "@/lib/supabase/server";
 import {
   getAllowanceHolderQuote,
   ZeroxNotConfiguredError,
+  type AllowanceHolderQuote,
 } from "@/lib/zerox/quote";
 
 import { ensureErc20Allowance, ensureUsdcAllowance } from "@/lib/execution/allowance";
@@ -26,7 +33,10 @@ import {
 import { computeSwapFeeUsdc } from "@/lib/execution/fees";
 import { deriveExecutionId } from "@/lib/execution/ids";
 import { parseCommandIntent } from "@/lib/execution/parse";
-import { validatePolicy, type PolicyContext } from "@/lib/execution/policy";
+import {
+  validatePolicy,
+  type PolicyContext,
+} from "@/lib/execution/policy";
 import { publishReplyOnce } from "@/lib/execution/reply-guard";
 import {
   reserveOrLoadExecution,
@@ -36,6 +46,7 @@ import { applyLotsAndPositionsForExecution } from "@/lib/execution/lot-persisten
 import { scoreTradeAfterExecution } from "@/lib/scoring/score-trade";
 import {
   decodeSwapReceipt,
+  findDisallowedWalletTokens,
   SwapLogMissingError,
   type SwapDirection,
 } from "@/lib/execution/swap-logs";
@@ -74,7 +85,7 @@ export interface CommandContext {
  *
  * The happy path is fully implemented through `decode_swap_log` (#26),
  * FIFO lot accounting (#10), and the scoring engine (#11). Score-time
- * price-impact (#12) remains a pass-through placeholder.
+ * price-impact (#12) compares the realized fill to a reference 0x quote.
  */
 export async function handleCommodusCommand(ctx: CommandContext) {
   "use workflow";
@@ -204,7 +215,10 @@ export async function handleCommodusCommand(ctx: CommandContext) {
     });
 
     if (!sellDecoded.ok) {
-      await markTradeExecutionFailed(sellReservation.tradeExecutionId);
+      await markTradeExecutionFailed(
+        sellReservation.tradeExecutionId,
+        sellDecoded.reason,
+      );
       await markRejected(ctx.castHash, sellDecoded.reason, "failed");
       await publishOutcomeReply(
         ctx.castHash,
@@ -222,11 +236,18 @@ export async function handleCommodusCommand(ctx: CommandContext) {
 
     const sellEnforcement = await scoreTimeEnforcement({
       tradeExecutionId: sellReservation.tradeExecutionId,
-      quotedNotional: sellReservation.reservedFillUsdc,
       maxPriceImpactBps: policy.context.policy.maxPriceImpactBps,
+      maxSlippageBps: policy.context.policy.maxSlippageBps,
+      taker: policy.context.walletAddress,
+      assetAddress: policy.context.assetAddress,
+      assetDecimals: policy.context.assetDecimals,
     });
 
     if (!sellEnforcement.ok) {
+      await markTradeExecutionFailed(
+        sellReservation.tradeExecutionId,
+        sellEnforcement.reason,
+      );
       await markRejected(ctx.castHash, sellEnforcement.reason, "failed");
       await publishOutcomeReply(
         ctx.castHash,
@@ -343,7 +364,7 @@ export async function handleCommodusCommand(ctx: CommandContext) {
   });
 
   if (!decoded.ok) {
-    await markTradeExecutionFailed(reservation.tradeExecutionId);
+    await markTradeExecutionFailed(reservation.tradeExecutionId, decoded.reason);
     await markRejected(ctx.castHash, decoded.reason, "failed");
     await publishOutcomeReply(
       ctx.castHash,
@@ -361,11 +382,18 @@ export async function handleCommodusCommand(ctx: CommandContext) {
 
   const enforcement = await scoreTimeEnforcement({
     tradeExecutionId: reservation.tradeExecutionId,
-    quotedNotional: reservation.reservedFillUsdc,
     maxPriceImpactBps: policy.context.policy.maxPriceImpactBps,
+    maxSlippageBps: policy.context.policy.maxSlippageBps,
+    taker: policy.context.walletAddress,
+    assetAddress: policy.context.assetAddress,
+    assetDecimals: policy.context.assetDecimals,
   });
 
   if (!enforcement.ok) {
+    await markTradeExecutionFailed(
+      reservation.tradeExecutionId,
+      enforcement.reason,
+    );
     await markRejected(ctx.castHash, enforcement.reason, "failed");
     await publishOutcomeReply(
       ctx.castHash,
@@ -519,6 +547,13 @@ async function resolveArenaWallet(
   };
 }
 
+function rethrowZeroxNotConfiguredAsFatal(err: unknown): never {
+  if (err instanceof ZeroxNotConfiguredError) {
+    throw new FatalError(err.message);
+  }
+  throw err;
+}
+
 async function policyValidate(params: {
   userId: string;
   walletId: string;
@@ -528,7 +563,11 @@ async function policyValidate(params: {
 }) {
   "use step";
 
-  return await validatePolicy(params);
+  try {
+    return await validatePolicy(params);
+  } catch (err) {
+    rethrowZeroxNotConfiguredAsFatal(err);
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -589,10 +628,7 @@ async function quoteAndReserve(params: {
       slippageBps: params.ctx.policy.maxSlippageBps,
     });
   } catch (err) {
-    if (err instanceof ZeroxNotConfiguredError) {
-      throw new FatalError(err.message);
-    }
-    throw err;
+    rethrowZeroxNotConfiguredAsFatal(err);
   }
 
   if (!quote.liquidityAvailable) {
@@ -641,10 +677,7 @@ async function quoteAndReserveSell(params: {
       slippageBps: params.ctx.policy.maxSlippageBps,
     });
   } catch (err) {
-    if (err instanceof ZeroxNotConfiguredError) {
-      throw new FatalError(err.message);
-    }
-    throw err;
+    rethrowZeroxNotConfiguredAsFatal(err);
   }
 
   if (!quote.liquidityAvailable) {
@@ -884,7 +917,7 @@ async function verifyTxOnchain(params: {
   if (receipt.status !== "success") {
     await supabaseAdmin
       .from("trade_executions")
-      .update({ status: "reverted" })
+      .update({ status: "reverted", failure_reason: "revert" })
       .eq("id", params.tradeExecutionId);
     throw new Error(`verify_tx_onchain: tx ${params.txHash} reverted`);
   }
@@ -918,7 +951,10 @@ async function verifyTxOnchain(params: {
 // ---------------------------------------------------------------------------
 
 const DECODE_TOLERANCE_BPS = 10;
-type DecodeFailureReason = "decode_log_missing" | "decode_log_mismatch";
+type DecodeFailureReason =
+  | "decode_log_missing"
+  | "decode_log_mismatch"
+  | "non_whitelisted_token";
 
 type DecodeSwapLogResult =
   | {
@@ -993,6 +1029,15 @@ async function decodeSwapLog(params: {
     throw err;
   }
 
+  const rogue = findDisallowedWalletTokens(
+    receipt,
+    params.walletAddress,
+    getAddress(params.assetAddress),
+  );
+  if (rogue.length > 0) {
+    return { ok: false, reason: "non_whitelisted_token" };
+  }
+
   // 10 bps sanity check: aggregator routing can round dust in either
   // direction, but a >0.1% gap between the reserved notional and the
   // realized USDC-out almost always means we're decoding the wrong tx
@@ -1030,43 +1075,180 @@ async function decodeSwapLog(params: {
 
 async function markTradeExecutionFailed(
   tradeExecutionId: string,
+  failureReason: string,
 ): Promise<void> {
   "use step";
 
   await supabaseAdmin
     .from("trade_executions")
-    .update({ status: "failed" })
+    .update({ status: "failed", failure_reason: failureReason })
     .eq("id", tradeExecutionId);
+}
+
+function quantityFieldToParseString(q: number | string, fractionDigits: number) {
+  if (typeof q === "number") {
+    return q.toFixed(fractionDigits);
+  }
+  return String(q).trim();
+}
+
+async function fetchReferenceZeroxQuoteForImpactCheck(params: {
+  intentAction: "buy" | "sell";
+  assetAddress: `0x${string}`;
+  assetDecimals: number;
+  quantity: number | string | null;
+  notionalUsdc: number | string | null;
+  taker: `0x${string}`;
+  slippageBps: number;
+  blockNumber: bigint;
+}): Promise<AllowanceHolderQuote> {
+  const errors: string[] = [];
+
+  for (const delta of [BigInt(0), BigInt(1), BigInt(-1)]) {
+    const bn = params.blockNumber + delta;
+    if (bn < BigInt(0)) continue;
+    try {
+      if (params.intentAction === "buy") {
+        const usdcHuman = Number(params.notionalUsdc ?? 0);
+        const sellWei = parseUnits(
+          usdcHuman.toFixed(USDC_DECIMALS),
+          USDC_DECIMALS,
+        );
+        return await getAllowanceHolderQuote({
+          sellToken: USDC_BASE_ADDRESS,
+          buyToken: params.assetAddress,
+          sellAmount: sellWei.toString(),
+          taker: params.taker,
+          slippageBps: params.slippageBps,
+          blockNumber: bn,
+        });
+      }
+
+      const qtyStr = quantityFieldToParseString(
+        params.quantity ?? "0",
+        params.assetDecimals,
+      );
+      const sellWei = parseUnits(qtyStr, params.assetDecimals);
+      return await getAllowanceHolderQuote({
+        sellToken: params.assetAddress,
+        buyToken: USDC_BASE_ADDRESS,
+        sellAmount: sellWei.toString(),
+        taker: params.taker,
+        slippageBps: params.slippageBps,
+        blockNumber: bn,
+      });
+    } catch (err) {
+      errors.push(err instanceof Error ? err.message : String(err));
+    }
+  }
+
+  throw new Error(
+    `reference 0x quote failed (±1 block): ${errors.join(" | ")}`,
+  );
 }
 
 // ---------------------------------------------------------------------------
 // Step: score_time_enforcement
 //
-// MVP: checks that realized fill is within the configured price-impact
-// tolerance. Reads the trade_executions row to see if we already stamped
-// a failure (idempotent).
+// Compares realized on-chain fill vs. a reference 0x quote at the confirm
+// block (±1). Breach → `price_impact` without scoring.
 // ---------------------------------------------------------------------------
 
 async function scoreTimeEnforcement(params: {
   tradeExecutionId: string;
-  quotedNotional: number;
   maxPriceImpactBps: number;
-}): Promise<
-  { ok: true } | { ok: false; reason: string }
-> {
+  maxSlippageBps: number;
+  taker: Address;
+  assetAddress: Address;
+  assetDecimals: number;
+}): Promise<{ ok: true } | { ok: false; reason: string }> {
   "use step";
 
-  // TODO: decode swap log + compute actual price impact vs oracle. For
-  // MVP we pass through so the happy path completes; the reconciler
-  // and a follow-up issue will wire the price-impact guard properly.
+  const { data: row, error: rowErr } = await supabaseAdmin
+    .from("trade_executions")
+    .select(
+      "status, failure_reason, tx_hash, quantity, notional_usdc, trade_intents!inner(action)",
+    )
+    .eq("id", params.tradeExecutionId)
+    .single();
+
+  if (rowErr || !row) {
+    throw new Error(`score_time_enforcement: load failed: ${rowErr?.message}`);
+  }
+
+  if (row.status === "failed" && row.failure_reason === "price_impact") {
+    return { ok: false, reason: "price_impact" };
+  }
+
+  const intent = row.trade_intents as { action: string };
+
+  if (
+    row.quantity == null ||
+    row.notional_usdc == null ||
+    !row.tx_hash ||
+    (intent.action !== "buy" && intent.action !== "sell")
+  ) {
+    return { ok: true };
+  }
+
+  const receipt = await basePublicClient.getTransactionReceipt({
+    hash: row.tx_hash as Hex,
+  });
+
+  let ref: AllowanceHolderQuote;
+  try {
+    ref = await fetchReferenceZeroxQuoteForImpactCheck({
+      intentAction: intent.action,
+      assetAddress: params.assetAddress,
+      assetDecimals: params.assetDecimals,
+      quantity: row.quantity,
+      notionalUsdc: row.notional_usdc,
+      taker: params.taker,
+      slippageBps: params.maxSlippageBps,
+      blockNumber: receipt.blockNumber,
+    });
+  } catch (err) {
+    rethrowZeroxNotConfiguredAsFatal(err);
+  }
+
+  if (!ref.liquidityAvailable) {
+    return { ok: true };
+  }
+
+  const refOutWei = BigInt(ref.buyAmount);
+  if (refOutWei === BigInt(0)) {
+    return { ok: true };
+  }
+
+  let actualOutWei: bigint;
+  if (intent.action === "buy") {
+    const qtyStr = quantityFieldToParseString(
+      row.quantity,
+      params.assetDecimals,
+    );
+    actualOutWei = parseUnits(qtyStr, params.assetDecimals);
+  } else {
+    const usdcHuman = Number(row.notional_usdc);
+    actualOutWei = parseUnits(usdcHuman.toFixed(USDC_DECIMALS), USDC_DECIMALS);
+  }
+
+  const diff =
+    actualOutWei > refOutWei
+      ? actualOutWei - refOutWei
+      : refOutWei - actualOutWei;
+  const impactBps = Number((diff * BigInt(10_000)) / refOutWei);
+
+  if (impactBps > params.maxPriceImpactBps) {
+    return { ok: false, reason: "price_impact" };
+  }
+
   return { ok: true };
 }
 
 // ---------------------------------------------------------------------------
 // Step: update_lots_and_positions
 //
-// Placeholder: real FIFO bookkeeping is a follow-up. We record a single
-// `positions` row upsert so the Arena page has something to render.
+// FIFO lot / position persistence via `applyLotsAndPositionsForExecution`.
 // ---------------------------------------------------------------------------
 
 async function updateLotsAndPositions(params: {
@@ -1174,9 +1356,6 @@ function parseRejectionFor(reason: string): {
       errorReason: "non_whitelisted_token",
       reply: REJECTION_REPLIES.non_whitelisted_token,
     };
-  }
-  if (reason === "oversize_error") {
-    return { errorReason: "oversize", reply: REJECTION_REPLIES.oversize };
   }
   // Defensive: unknown reasons fall through to the generic outcome copy
   // so a future parser shape doesn't silently drop the reply.

--- a/lib/zerox/quote.ts
+++ b/lib/zerox/quote.ts
@@ -129,6 +129,11 @@ export type GetAllowanceHolderQuoteParams = {
    * default `max_slippage_bps`.
    */
   slippageBps?: number;
+  /**
+   * Optional execution block hint for reference quotes (price-impact).
+   * Passed through to 0x when supported by the API.
+   */
+  blockNumber?: bigint | number | string;
 };
 
 /**
@@ -151,6 +156,10 @@ export async function getAllowanceHolderQuote(
     taker: params.taker,
     slippageBps: String(params.slippageBps ?? 100),
   });
+
+  if (params.blockNumber !== undefined) {
+    qs.set("blockNumber", String(params.blockNumber));
+  }
 
   const response = await fetch(
     `${ZEROX_API_BASE}/swap/allowance-holder/quote?${qs.toString()}`,

--- a/supabase/migrations/20260419180606_remote_baseline.sql
+++ b/supabase/migrations/20260419180606_remote_baseline.sql
@@ -1,0 +1,4 @@
+-- Baseline migration: applied on the hosted Supabase project before this
+-- version existed in git. Kept as a no-op so `supabase db push` / local
+-- migration order matches `supabase_migrations.schema_migrations`.
+select 1;

--- a/supabase/migrations/20260419215314_remote_baseline.sql
+++ b/supabase/migrations/20260419215314_remote_baseline.sql
@@ -1,0 +1,4 @@
+-- Baseline migration: applied on the hosted Supabase project before this
+-- version existed in git. Kept as a no-op so `supabase db push` / local
+-- migration order matches `supabase_migrations.schema_migrations`.
+select 1;

--- a/supabase/migrations/20260419220000_issue_12_execution_hardening.sql
+++ b/supabase/migrations/20260419220000_issue_12_execution_hardening.sql
@@ -1,0 +1,8 @@
+-- Issue #12: structured execution failures for score-time enforcement,
+-- whitelist violations, and operator telemetry.
+
+alter table public.trade_executions
+  add column failure_reason text;
+
+comment on column public.trade_executions.failure_reason is
+  'Structured failure code when status is failed or reverted (price_impact, non_whitelisted_token, revert, etc.).';


### PR DESCRIPTION
## Summary
Implements [issue #12](https://github.com/hurley87/victus/issues/12): multi-asset whitelist at parse time, wallet cap and on-chain sell sizing, daily trade limits, score-time token allowlist + price-impact vs reference 0x quote, `failure_reason` on `trade_executions`, and templated outcome voice via `lib/commodus-voice.ts`.

## Migrations
- `failure_reason` column
- Remote baseline placeholders for hosted migration history alignment

## Testing
- `pnpm exec tsc --noEmit`
- Focused Vitest: parser, templates, swap-logs, fees

Closes #12

Made with [Cursor](https://cursor.com)